### PR TITLE
Add Claude Code session initialization hooks for Clojure

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only needed in remote (Claude Code on the web) environments.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install the Clojure CLI if it isn't already present.
+if ! command -v clojure >/dev/null 2>&1; then
+  curl -sL https://download.clojure.org/install/linux-install.sh -o /tmp/clj-install.sh
+  bash /tmp/clj-install.sh
+  rm -f /tmp/clj-install.sh
+fi
+
+# Pre-fetch project dependencies (idempotent; uses ~/.m2 cache).
+cd "$CLAUDE_PROJECT_DIR"
+clojure -P -A:dev:test 2>&1 | grep -v 'Use of :main-opts with -A is deprecated' || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Claude Code environment initialization configuration to automatically set up the Clojure development environment when starting a remote session.

## Key Changes
- **`.claude/hooks/session-start.sh`**: New bash script that runs during session initialization in remote Claude Code environments
  - Installs the Clojure CLI tool if not already present
  - Pre-fetches project dependencies using `clojure -P` to populate the Maven cache (~/.m2)
  - Only executes in remote environments (checks `CLAUDE_CODE_REMOTE` flag)
  - Suppresses deprecation warnings from the Clojure CLI

- **`.claude/settings.json`**: New configuration file that registers the session start hook
  - Defines the `SessionStart` hook to execute the initialization script
  - Integrates with Claude Code's hook system for automatic environment setup

## Implementation Details
- The session start script is idempotent and safe to run multiple times
- Dependency pre-fetching uses the `-A:dev:test` aliases to include all development and test dependencies
- The script gracefully handles cases where Clojure is already installed
- Error output filtering prevents deprecation warnings from cluttering the session initialization logs

https://claude.ai/code/session_01SPJUxy3sdgnrf6BvC2BoiU