### PR TITLE
Add issuer metadata caching and proactive token refresh

### DIFF
--- a/src/atproto/credentials.cljc
+++ b/src/atproto/credentials.cljc
@@ -63,12 +63,26 @@
                                    (xrpc-create-session identity credentials cb))))
     val))
 
+(defn- session-killing-error?
+  "True when this refreshSession failure means the session is definitively
+  dead (HTTP 401, ExpiredToken, InvalidToken). Network and other transient
+  errors return false."
+  [{:keys [error http-response]}]
+  (boolean
+   (or (contains? #{"ExpiredToken" "InvalidToken"} error)
+       (= 401 (:status http-response)))))
+
 (defn- xrpc-refresh-session
   "Session protocol impl. POSTs com.atproto.server.refreshSession through a
   refresh-mode XRPC client. cb receives the rebuilt session (new
   accessJwt/refreshJwt, metadata reattached) or {:error ...}. Delivers
   {:error \"InvalidDID\" ...} if the response :did differs from the current
-  session's."
+  session's.
+
+  Definitive failures (HTTP 401, InvalidDID, ExpiredToken, InvalidToken) are
+  tagged with :atproto.xrpc.client/session-expired? so the XRPC client drops
+  the dead session; transient failures (e.g. network errors) leave it in
+  place."
   [sess cb]
   (xrpc-client/procedure (refresh-client sess)
                          {:nsid "com.atproto.server.refreshSession"}
@@ -76,12 +90,15 @@
                          (fn [{:keys [error] :as resp}]
                            (cond
                              error
-                             (cb resp)
+                             (cb (cond-> resp
+                                   (session-killing-error? resp)
+                                   (assoc ::xrpc-client/session-expired? true)))
 
                              (and (:did sess) (not= (:did sess) (:did resp)))
                              (cb {:error "InvalidDID"
                                   :message "The DID changed across the session refresh."
-                                  :did (:did resp)})
+                                  :did (:did resp)
+                                  ::xrpc-client/session-expired? true})
 
                              :else
                              (cb (session sess resp))))))

--- a/src/atproto/oauth/client.cljc
+++ b/src/atproto/oauth/client.cljc
@@ -97,13 +97,20 @@
      :state-store (or state-store (store/memory-store))
      :session-store (or session-store (store/memory-store))}))
 
+;; How long fetched authorization-server metadata may be reused, in seconds.
+(def issuer-metadata-ttl 60)
+
 (defn- set-issuer!
   [client iss metadata]
-  (swap! (:issuers client) assoc iss metadata))
+  (swap! (:issuers client) assoc iss {:metadata metadata
+                                      :expires-at (+ (crypto/now) issuer-metadata-ttl)}))
 
 (defn- get-issuer
+  "The cached authorization-server metadata for `iss`, if still fresh."
   [client iss]
-  (get @(:issuers client) iss))
+  (when-let [{:keys [metadata expires-at]} (get @(:issuers client) iss)]
+    (when (< (crypto/now) expires-at)
+      metadata)))
 
 (defn- after-delay
   "Invoke f after ms milliseconds, off the calling thread."
@@ -137,10 +144,10 @@
 (defn- issuer-metadata
   "The authorization-server metadata for `iss`.
 
-  Returns the cached entry, or fetches it from
-  <iss>/.well-known/oauth-authorization-server, validates that the metadata's
-  issuer matches, and caches it. Makes refresh/revoke work after a process
-  restart, when the in-memory issuer cache is empty."
+  Returns the cached entry (fresh for `issuer-metadata-ttl`), or fetches it
+  from <iss>/.well-known/oauth-authorization-server, validates that the
+  metadata's issuer matches, and caches it. Makes refresh/revoke/callback
+  work after a process restart, when the in-memory issuer cache is empty."
   [client iss cb]
   (if-let [metadata (get-issuer client iss)]
     (cb metadata)
@@ -418,7 +425,6 @@
 
   Return a map with:
   :state    The local state stored for this session.
-  :issuer   The issuer for this request.
   :error    In case of an error."
   [client {:keys [response iss state error code] :as params}]
   (let [saved-state (store/get (:state-store client) state)]
@@ -443,8 +449,7 @@
                :state saved-state}
 
               :else
-              {:state saved-state
-               :issuer (get-issuer client iss)})))))
+              {:state saved-state})))))
 
 (defn callback
   "Exchange the authorization code for OAuth tokens and return a OAuth session.
@@ -459,43 +464,76 @@
   :state    The app state passed in authorize, if any."
   [client params & {:as opts}]
   (let [[cb val] (i/platform-async opts)
-        {:keys [error state issuer] :as resp} (validate-callback-params client params)]
+        {:keys [error state] :as resp} (validate-callback-params client params)]
     (if error
       (cb resp)
-      (let [{:keys [verifier dpop-key app-state identity]} state
-            server {:issuer issuer
-                    :dpop-key dpop-key}]
-        (exchange-code client server {:code (:code params)
-                                      :verifier verifier}
-                       (fn [{:keys [error] :as resp}]
-                         (if error
-                           (cb resp)
-                           (let [did (:sub resp)
-                                 iss (:issuer issuer)
-                                 session-data (merge identity
-                                                     {:did did
-                                                      :iss iss
-                                                      :tokens (tokens+expiry iss (:aud resp) resp)
-                                                      :dpop-key dpop-key})
-                                 store-session! (fn []
-                                                  (store/set (:session-store client) did session-data)
-                                                  (cb (cond-> {:session (oauth-session client session-data)}
-                                                        app-state (assoc :state app-state))))]
-                             ;; revoke any pre-existing session for the same DID
-                             (if-let [existing (store/get (:session-store client) did)]
-                               (revoke-tokens client existing (fn [_] (store-session!)))
-                               (store-session!))))))))
+      (let [{:keys [verifier dpop-key app-state identity]} state]
+        (issuer-metadata
+         client (:iss state)
+         (fn [{:keys [error] :as issuer}]
+           (if error
+             (cb issuer)
+             (let [server {:issuer issuer
+                           :dpop-key dpop-key}]
+               (exchange-code client server {:code (:code params)
+                                             :verifier verifier}
+                              (fn [{:keys [error] :as resp}]
+                                (if error
+                                  (cb resp)
+                                  (let [did (:sub resp)
+                                        iss (:issuer issuer)
+                                        session-data (merge identity
+                                                            {:did did
+                                                             :iss iss
+                                                             :tokens (tokens+expiry iss (:aud resp) resp)
+                                                             :dpop-key dpop-key})
+                                        store-session! (fn []
+                                                         (store/set (:session-store client) did session-data)
+                                                         (cb (cond-> {:session (oauth-session client session-data)}
+                                                               app-state (assoc :state app-state))))]
+                                    ;; revoke any pre-existing session for the same DID
+                                    (if-let [existing (store/get (:session-store client) did)]
+                                      (revoke-tokens client existing (fn [_] (store-session!)))
+                                      (store-session!))))))))))))
     val))
+
+;; Tokens are considered stale this many seconds before :expires-at, plus a
+;; random jitter to spread refreshes across concurrent instances.
+(def token-expiry-leeway 10)
+(def token-expiry-jitter 30)
+
+(defn- stale-tokens?
+  "True when these tokens are expired or about to expire. Tokens without
+  :expires-at (legacy rows) are never considered stale."
+  [{:keys [expires-at]}]
+  (boolean
+   (and expires-at
+        (< expires-at (+ (crypto/now)
+                         token-expiry-leeway
+                         (rand-int token-expiry-jitter))))))
 
 (defn restore
   "The OAuth session for this did.
 
   Resolves to the session or {:error \"SessionNotFound\" :did did}.
-  Tolerates legacy stored sessions without :iss/:expires-at."
-  [client did & {:as opts}]
-  (let [[cb val] (i/platform-async opts)]
+
+  The :refresh option controls token freshness:
+  :auto (default)  refresh first when the stored tokens are expired or about
+                   to expire (see `stale-tokens?`)
+  true             always refresh first
+  false            return the stored tokens as-is, even if expired
+
+  Tolerates legacy stored sessions without :iss/:expires-at (never refreshed
+  proactively, only on an invalid-token response)."
+  [client did & {:keys [refresh] :or {refresh :auto} :as opts}]
+  (let [[cb val] (i/platform-async (dissoc opts :refresh))]
     (if-let [session-data (store/get (:session-store client) did)]
-      (cb (oauth-session client session-data))
+      (if (case refresh
+            true true
+            false false
+            (stale-tokens? (:tokens session-data)))
+        (refresh-session client {:did did} cb)
+        (cb (oauth-session client session-data)))
       (cb {:error "SessionNotFound" :did did}))
     val))
 
@@ -524,15 +562,17 @@
                (store/del session-store did))
              (cb {:error "TokenRefreshError"
                   :message (or error_description "The refresh token grant was rejected.")
-                  :did did})))))))
+                  :did did
+                  ::xrpc-client/session-expired? true})))))))
 
 (defn- run-refresh
   "Perform the refresh_token grant for the stored session of this DID.
 
   cb receives a new session (satisfying xrpc-client/Session) or {:error ...}.
-  Definitive failures delete the stored session; transient failures (network,
-  5xx) leave it in place. The refreshed tokens are persisted via store/set
-  before the new session is delivered."
+  Definitive failures delete the stored session and are tagged with
+  :atproto.xrpc.client/session-expired? so XRPC clients drop the dead session;
+  transient failures (network, 5xx) leave it in place. The refreshed tokens
+  are persisted via store/set before the new session is delivered."
   [client did cb]
   (let [session-store (:session-store client)
         stored (store/get session-store did)]
@@ -540,13 +580,15 @@
       (not stored)
       (cb {:error "TokenRefreshError"
            :message "Session deleted."
-           :did did})
+           :did did
+           ::xrpc-client/session-expired? true})
 
       (not (get-in stored [:tokens :refresh_token]))
       (do (store/del session-store did)
           (cb {:error "TokenRefreshError"
                :message "No refresh token available."
-               :did did}))
+               :did did
+               ::xrpc-client/session-expired? true}))
 
       :else
       ;; Re-verify the issuer for this DID before using the refresh token.
@@ -561,7 +603,8 @@
                    (do (store/del session-store did)
                        (cb {:error "TokenRefreshError"
                             :message "Issuer mismatch."
-                            :did did}))
+                            :did did
+                            ::xrpc-client/session-expired? true}))
 
                    :else
                    (let [iss (or (:iss stored) iss)
@@ -579,10 +622,12 @@
                            (fn [{:keys [error] :as token-resp}]
                              (cond
                                (not error)
+                               ;; pin :sub to the session's DID; the token
+                               ;; response's sub is not re-validated here
                                (let [session-data (merge stored
                                                          {:iss iss
                                                           :did-doc (:did-doc identity)
-                                                          :tokens (tokens+expiry iss aud (update token-resp :sub #(or % did)))}
+                                                          :tokens (tokens+expiry iss aud (assoc token-resp :sub did))}
                                                          (when (:handle identity)
                                                            {:handle (:handle identity)}))]
                                  (store/set session-store did session-data)

--- a/src/atproto/xrpc/client.cljc
+++ b/src/atproto/xrpc/client.cljc
@@ -50,8 +50,11 @@
 
      MUST eventually call cb exactly once with either a NEW session value
      (satisfying Session, with refreshed tokens) or an {:error ...} map.
-     Implementations must never throw out of the calling thread without
-     invoking cb."))
+     Error maps may carry ::session-expired? true to signal that the session
+     is definitively dead (e.g. the server rejected the refresh token); the
+     client then drops its session and subsequent requests are sent
+     unauthenticated. Implementations must never throw out of the calling
+     thread without invoking cb."))
 
 (defn invalid-token-response?
   "True if this HTTP response indicates the access token was rejected and a
@@ -87,7 +90,8 @@
   an {:error ...} map. The first caller triggers the session's refresh-token;
   callers that arrive while a refresh is in flight queue on its result. On
   success the client's session atom is reset to the new session before any
-  waiter is invoked."
+  waiter is invoked; on an error carrying ::session-expired? the session atom
+  is reset to nil (the session is dropped)."
   [{:keys [session ::refresh-state]} cb]
   (let [[prev _] (swap-vals! refresh-state
                              (fn [state]
@@ -100,7 +104,9 @@
                        (when (compare-and-set! delivered? false true)
                          (let [[{:keys [waiters]} _] (swap-vals! refresh-state
                                                                 (constantly nil))]
-                           (when-not (:error result)
+                           (if (:error result)
+                             (when (::session-expired? result)
+                               (reset! session nil))
                              (reset! session result))
                            (run! #(% result) waiters))))]
         (try
@@ -124,7 +130,11 @@
   new session, or continues with the full {:error ...} map from the refresh
   callback as the response. A retried request that fails again with an
   invalid-token response is returned to the caller as-is (no second refresh).
-  The leave fn returns nil after handing off to i/continue."
+  The leave fn returns nil after handing off to i/continue.
+
+  A session dropped after a definitive refresh failure (see ::session-expired?
+  on `refresh-token`) leaves nil in the session atom: subsequent requests are
+  sent unauthenticated and no further refresh is attempted."
   [{:keys [session] :as client}]
   (let [wrap-auth (fn [ctx]
                     (-> ctx
@@ -132,11 +142,12 @@
                         (update ::i/queue #(cons (auth-interceptor @session) %))))]
     {::i/name ::delegate-auth-interceptor
      ::i/enter (fn [ctx]
-                 (if session
+                 (if (and session @session)
                    (wrap-auth ctx)
                    ctx))
      ::i/leave (fn [{:keys [::i/response ::original-ctx] :as ctx}]
                  (if (and session
+                          @session
                           (invalid-token-response? response)
                           (not (:refresh? @session))
                           (not (::auth-retried? ctx)))

--- a/test/atproto/credentials_test.cljc
+++ b/test/atproto/credentials_test.cljc
@@ -107,7 +107,49 @@
                resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
                                                         :body {:n 1}})
                            2000 ::timeout)]
-           (is (= "InvalidDID" (:error resp))))))))
+           (is (= "InvalidDID" (:error resp)))
+           ;; a DID change is definitive: the session is dropped
+           (is (nil? @(:session xrpc))))))))
+
+#?(:clj
+   (deftest refresh-definitive-failure-drops-session-test
+     ;; a refreshSession rejected with ExpiredToken means the session is dead:
+     ;; the error is delivered and the client drops its session
+     (let [{:keys [handler]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["refreshSession" (fake-http/json-response 400 {:error "ExpiredToken"})]
+             ["" (fake-http/json-response 400 {:error "ExpiredToken"})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               xrpc (xrpc-client/init {:session session})
+               resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
+                                                        :body {:n 1}})
+                           2000 ::timeout)]
+           (is (= "ExpiredToken" (:error resp)))
+           (is (nil? @(:session xrpc))))))))
+
+#?(:clj
+   (deftest refresh-network-failure-keeps-session-test
+     ;; a transient refresh failure leaves the session in place
+     (let [{:keys [handler]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["refreshSession" {:error "HTTPClientError"
+                                :message "connection refused"}]
+             ["" (fake-http/json-response 400 {:error "ExpiredToken"})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               xrpc (xrpc-client/init {:session session})
+               resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
+                                                        :body {:n 1}})
+                           2000 ::timeout)]
+           (is (= "HTTPClientError" (:error resp)))
+           (is (= "access-1" (:accessJwt @(:session xrpc)))))))))
 
 #?(:clj
    (deftest logout-test

--- a/test/atproto/oauth/client_test.clj
+++ b/test/atproto/oauth/client_test.clj
@@ -41,6 +41,19 @@
                                    :redirect_uris ["https://app.test/oauth/callback"]
                                    :scope "atproto"}}))
 
+(defn- tokens
+  "A stored token map with a future expiry, merged with `overrides`."
+  [& [overrides]]
+  (merge {:access_token "at-1"
+          :refresh_token "rt-1"
+          :token_type "DPoP"
+          :scope "atproto"
+          :sub did
+          :aud pds
+          :iss issuer
+          :expires-at (+ (crypto/now) 3600)}
+         overrides))
+
 (defn- seed-session!
   "Store a session for `did` and return the session data (with the dpop-key)."
   [client & [overrides]]
@@ -50,14 +63,7 @@
                              :did-doc did-doc
                              :iss issuer
                              :dpop-key dpop-key
-                             :tokens {:access_token "at-1"
-                                      :refresh_token "rt-1"
-                                      :token_type "DPoP"
-                                      :scope "atproto"
-                                      :sub did
-                                      :aud pds
-                                      :iss issuer
-                                      :expires-at 0}}
+                             :tokens (tokens)}
                             overrides)]
     (store/set (:session-store client) did session-data)
     session-data))
@@ -135,6 +141,49 @@
           (is (= "at-2" (get-in s2 [:tokens :access_token])))
           (is (= 1 (count (requests-to requests "/token")))))))))
 
+(deftest refresh-pins-sub-test
+  ;; the token response's sub is not adopted: the stored sub stays pinned to
+  ;; the session's DID (matching the reference, which ignores it on refresh)
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler]} (fake-http/routed
+                           (conj resolution-routes
+                                 ["/token" (fake-http/json-response
+                                            {:access_token "at-2"
+                                             :refresh_token "rt-2"
+                                             :token_type "DPoP"
+                                             :scope "atproto"
+                                             :sub "did:plc:zzzzzzzzzzzzzzzzzzzzzzzz"
+                                             :expires_in 300})]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/refresh client did) 5000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= did (get-in session [:tokens :sub])))
+        (is (= did (get-in (store/get (:session-store client) did) [:tokens :sub])))))))
+
+(deftest issuer-metadata-cache-ttl-test
+  ;; AS metadata is cached for issuer-metadata-ttl and re-fetched after that
+  (let [client (test-client)
+        {:keys [handler requests]} (fake-http/routed
+                                    [["/.well-known/oauth-authorization-server"
+                                      (fake-http/json-response asmd)]
+                                     ["/revoke" (fake-http/json-response {})]])
+        asmd-fetches #(count (requests-to requests "oauth-authorization-server"))]
+    (with-redefs [http/handle-request handler]
+      ;; first revoke fetches and caches the metadata, second hits the cache
+      (seed-session! client)
+      (is (= {:did did :revoked true} (deref (oauth/revoke client did) 5000 ::timeout)))
+      (is (= 1 (asmd-fetches)))
+      (seed-session! client)
+      (is (= {:did did :revoked true} (deref (oauth/revoke client did) 5000 ::timeout)))
+      (is (= 1 (asmd-fetches)))
+      ;; past the TTL the metadata is fetched again
+      (let [real-now crypto/now]
+        (with-redefs [crypto/now #(+ (real-now) (* 2 oauth/issuer-metadata-ttl))]
+          (seed-session! client)
+          (is (= {:did did :revoked true} (deref (oauth/revoke client did) 5000 ::timeout)))
+          (is (= 2 (asmd-fetches))))))))
+
 (deftest invalid-grant-adopts-foreign-refresh-test
   (let [client (test-client)
         seeded (seed-session! client)
@@ -168,6 +217,8 @@
       (let [resp (deref (oauth/refresh client did) 5000 ::timeout)]
         (is (= "TokenRefreshError" (:error resp)))
         (is (= "expired" (:message resp)))
+        ;; definitive failures are tagged so XRPC clients drop the session
+        (is (true? (:atproto.xrpc.client/session-expired? resp)))
         (is (nil? (store/get (:session-store client) did)))))))
 
 (deftest refresh-without-refresh-token-test
@@ -204,12 +255,51 @@
 
 (deftest restore-test
   (let [client (test-client)
-        _ (seed-session! client)]
-    (let [session (deref (oauth/restore client did) 1000 ::timeout)]
-      (is (nil? (:error session)))
-      (is (= did (:did session)))
-      (is (= pds (:pds session)))
-      (is (map? (xrpc-client/auth-interceptor session))))))
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed [])]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did) 1000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= did (:did session)))
+        (is (= pds (:pds session)))
+        (is (map? (xrpc-client/auth-interceptor session)))
+        ;; fresh tokens are returned as-is, without any network traffic
+        (is (empty? @requests))))))
+
+(deftest restore-refreshes-stale-tokens-test
+  ;; restore with the default :refresh :auto refreshes expired (or about to
+  ;; expire) tokens before returning the session
+  (let [client (test-client)
+        _ (seed-session! client {:tokens (tokens {:expires-at (crypto/now)})})
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/token" token-success-response]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did) 5000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= "at-2" (get-in session [:tokens :access_token])))
+        (is (= 1 (count (requests-to requests "/token"))))))))
+
+(deftest restore-refresh-false-returns-stale-tokens-test
+  (let [client (test-client)
+        _ (seed-session! client {:tokens (tokens {:expires-at 0})})
+        {:keys [handler requests]} (fake-http/routed [])]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did :refresh false) 1000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= "at-1" (get-in session [:tokens :access_token])))
+        (is (empty? @requests))))))
+
+(deftest restore-refresh-true-forces-refresh-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/token" token-success-response]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did :refresh true) 5000 ::timeout)]
+        (is (= "at-2" (get-in session [:tokens :access_token])))
+        (is (= 1 (count (requests-to requests "/token"))))))))
 
 (deftest restore-unknown-did-never-hangs-test
   (let [client (test-client)

--- a/test/atproto/xrpc/client_test.cljc
+++ b/test/atproto/xrpc/client_test.cljc
@@ -95,7 +95,30 @@
        (with-redefs [http/handle-request handler]
          (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
                            1000 ::timeout)]
-           (is (= {:error "TokenRefreshError" :message "x"} resp)))))))
+           (is (= {:error "TokenRefreshError" :message "x"} resp))
+           ;; a transient refresh failure keeps the session in place
+           (is (= "old" (:token @(:session xrpc)))))))))
+
+#?(:clj
+   (deftest definitive-refresh-failure-drops-session-test
+     ;; an error tagged ::client/session-expired? drops the session: the
+     ;; error is delivered and subsequent requests go out unauthenticated
+     (let [session (stub-session "old"
+                                 (fn [_ cb] (cb {:error "TokenRefreshError"
+                                                 ::client/session-expired? true})))
+           {:keys [handler requests]} (fake-http/scripted
+                                       [expired-response
+                                        (fake-http/json-response {:anon true})])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           (is (= "TokenRefreshError" (:error resp)))
+           (is (nil? @(:session xrpc)))
+           (let [resp2 (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                              1000 ::timeout)]
+             (is (= {:anon true} resp2))
+             (is (nil? (bearer (second @requests))))))))))
 
 #?(:clj
    (deftest refresh-token-throwing-delivers-error-test


### PR DESCRIPTION
## Summary
This PR improves OAuth session management by introducing issuer metadata caching with TTL and proactive token refresh. It also enhances session expiration handling to distinguish between definitive failures (which drop the session) and transient failures (which preserve it).

## Key Changes

- **Issuer metadata caching**: Authorization server metadata is now cached for `issuer-metadata-ttl` (60 seconds) and re-fetched after expiration, reducing redundant network requests during token refresh and revocation operations.

- **Proactive token refresh in `restore`**: The `restore` function now supports a `:refresh` option (`:auto` by default) to proactively refresh tokens before returning a session:
  - `:auto` (default): Refreshes tokens if they're expired or about to expire (within `token-expiry-leeway` + random jitter)
  - `true`: Always refreshes tokens
  - `false`: Returns stored tokens as-is, even if expired

- **Session expiration signaling**: Definitive refresh failures (HTTP 401, ExpiredToken, InvalidToken) are now tagged with `::xrpc-client/session-expired?` to signal that the session is dead. The XRPC client drops such sessions, causing subsequent requests to be sent unauthenticated. Transient failures (network errors, 5xx) leave the session in place.

- **Token refresh improvements**:
  - The `:sub` claim is now pinned to the session's DID during refresh (not adopted from the token response)
  - Refresh failures that delete the session are properly tagged for client-side handling
  - Added comprehensive error handling for missing refresh tokens and issuer mismatches

- **Enhanced session protocol**: The `Session` protocol's `refresh-token` method now documents the `::session-expired?` flag for signaling definitive failures.

## Implementation Details

- New constants: `issuer-metadata-ttl`, `token-expiry-leeway`, `token-expiry-jitter`
- New helper functions: `stale-tokens?`, `session-killing-error?`
- Issuer metadata now stored with expiration timestamp in the client's issuer cache
- Token expiry checks include random jitter to spread refreshes across concurrent instances
- Comprehensive test coverage for new caching, refresh, and session expiration behaviors

https://claude.ai/code/session_013QJ83JMiK3hDwUJphePX5W