### PR TITLE
Auth & session lifecycle (WS-01)

### DIFF
--- a/examples/statusphere/src/xyz/statusphere/server.clj
+++ b/examples/statusphere/src/xyz/statusphere/server.clj
@@ -46,7 +46,8 @@
               :session session)))
 
    (POST "/logout" req
-     ;; todo: destroy oauth session
+     (when-let [did (get-in req [:session :did])]
+       @(oauth-client/revoke (:oauth-client (:app-ctx req)) did))
      (assoc (r/redirect "/")
             :session nil))
 

--- a/src/atproto/credentials.cljc
+++ b/src/atproto/credentials.cljc
@@ -63,12 +63,26 @@
                                    (xrpc-create-session identity credentials cb))))
     val))
 
+(defn- session-killing-error?
+  "True when this refreshSession failure means the session is definitively
+  dead (HTTP 401, ExpiredToken, InvalidToken). Network and other transient
+  errors return false."
+  [{:keys [error http-response]}]
+  (boolean
+   (or (contains? #{"ExpiredToken" "InvalidToken"} error)
+       (= 401 (:status http-response)))))
+
 (defn- xrpc-refresh-session
   "Session protocol impl. POSTs com.atproto.server.refreshSession through a
   refresh-mode XRPC client. cb receives the rebuilt session (new
   accessJwt/refreshJwt, metadata reattached) or {:error ...}. Delivers
   {:error \"InvalidDID\" ...} if the response :did differs from the current
-  session's."
+  session's.
+
+  Definitive failures (HTTP 401, InvalidDID, ExpiredToken, InvalidToken) are
+  tagged with :atproto.xrpc.client/session-expired? so the XRPC client drops
+  the dead session; transient failures (e.g. network errors) leave it in
+  place."
   [sess cb]
   (xrpc-client/procedure (refresh-client sess)
                          {:nsid "com.atproto.server.refreshSession"}
@@ -76,12 +90,15 @@
                          (fn [{:keys [error] :as resp}]
                            (cond
                              error
-                             (cb resp)
+                             (cb (cond-> resp
+                                   (session-killing-error? resp)
+                                   (assoc ::xrpc-client/session-expired? true)))
 
                              (and (:did sess) (not= (:did sess) (:did resp)))
                              (cb {:error "InvalidDID"
                                   :message "The DID changed across the session refresh."
-                                  :did (:did resp)})
+                                  :did (:did resp)
+                                  ::xrpc-client/session-expired? true})
 
                              :else
                              (cb (session sess resp))))))

--- a/src/atproto/credentials.cljc
+++ b/src/atproto/credentials.cljc
@@ -7,16 +7,33 @@
 
 (declare auth-interceptor xrpc-refresh-session)
 
+(s/def ::accessJwt string?)
+(s/def ::refreshJwt string?)
+(s/def ::session
+  (s/keys :req-un [::accessJwt ::refreshJwt]))
+
 (defn- session
-  [{:keys [did didDoc handle accessJwt refreshJwt]}]
-  (with-meta
-    (cond-> {:accessJwt accessJwt
-             :refreshJwt refreshJwt}
-      did (assoc :did did)
-      didDoc (assoc :pds (identity/did-doc-pds didDoc))
-      handle (assoc :handle handle))
-    {`xrpc-client/auth-interceptor auth-interceptor
-     `xrpc-client/refresh-token xrpc-refresh-session}))
+  "Build a session map (with Session protocol metadata) from a
+  createSession/refreshSession response, falling back to `prev` for
+  :did/:pds/:handle when the response omits did/didDoc/handle."
+  ([resp] (session nil resp))
+  ([prev {:keys [did didDoc handle accessJwt refreshJwt]}]
+   (let [did (or did (:did prev))
+         pds (if didDoc (identity/did-doc-pds didDoc) (:pds prev))
+         handle (or handle (:handle prev))]
+     (with-meta
+       (cond-> {:accessJwt accessJwt
+                :refreshJwt refreshJwt}
+         did (assoc :did did)
+         pds (assoc :pds pds)
+         handle (assoc :handle handle))
+       {`xrpc-client/auth-interceptor auth-interceptor
+        `xrpc-client/refresh-token xrpc-refresh-session}))))
+
+(defn- refresh-client
+  "An XRPC client that authenticates with the session's refresh JWT."
+  [sess]
+  (xrpc-client/init {:session (assoc sess :refresh? true)}))
 
 (defn- xrpc-create-session
   "Call `createSession` on the PDS to authenticate those credentials."
@@ -46,16 +63,43 @@
                                    (xrpc-create-session identity credentials cb))))
     val))
 
-(defn xrpc-refresh-session
-  [session cb]
-  (xrpc-client/procedure (xrpc-client/init (assoc session :refresh? true))
+(defn- xrpc-refresh-session
+  "Session protocol impl. POSTs com.atproto.server.refreshSession through a
+  refresh-mode XRPC client. cb receives the rebuilt session (new
+  accessJwt/refreshJwt, metadata reattached) or {:error ...}. Delivers
+  {:error \"InvalidDID\" ...} if the response :did differs from the current
+  session's."
+  [sess cb]
+  (xrpc-client/procedure (refresh-client sess)
                          {:nsid "com.atproto.server.refreshSession"}
                          :callback
                          (fn [{:keys [error] :as resp}]
-                           (if error
+                           (cond
+                             error
                              (cb resp)
-                             (cb (merge session
-                                        (session resp)))))))
+
+                             (and (:did sess) (not= (:did sess) (:did resp)))
+                             (cb {:error "InvalidDID"
+                                  :message "The DID changed across the session refresh."
+                                  :did (:did resp)})
+
+                             :else
+                             (cb (session sess resp))))))
+
+(defn logout
+  "Invalidate the session server-side (com.atproto.server.deleteSession,
+  authenticated with the refreshJwt). Server errors are reported in the
+  result but the session should be considered dead regardless.
+
+  Async via :callback/:promise/:channel opts; resolves to {} or {:error ...}."
+  [session & {:as opts}]
+  (let [[cb val] (i/platform-async opts)]
+    (xrpc-client/procedure (refresh-client session)
+                           {:nsid "com.atproto.server.deleteSession"}
+                           :callback
+                           (fn [{:keys [error] :as resp}]
+                             (cb (if error resp {}))))
+    val))
 
 (defn auth-interceptor
   [{:keys [accessJwt refreshJwt refresh?] :as session}]

--- a/src/atproto/oauth/client.cljc
+++ b/src/atproto/oauth/client.cljc
@@ -97,13 +97,20 @@
      :state-store (or state-store (store/memory-store))
      :session-store (or session-store (store/memory-store))}))
 
+;; How long fetched authorization-server metadata may be reused, in seconds.
+(def issuer-metadata-ttl 60)
+
 (defn- set-issuer!
   [client iss metadata]
-  (swap! (:issuers client) assoc iss metadata))
+  (swap! (:issuers client) assoc iss {:metadata metadata
+                                      :expires-at (+ (crypto/now) issuer-metadata-ttl)}))
 
 (defn- get-issuer
+  "The cached authorization-server metadata for `iss`, if still fresh."
   [client iss]
-  (get @(:issuers client) iss))
+  (when-let [{:keys [metadata expires-at]} (get @(:issuers client) iss)]
+    (when (< (crypto/now) expires-at)
+      metadata)))
 
 (defn- after-delay
   "Invoke f after ms milliseconds, off the calling thread."
@@ -137,10 +144,10 @@
 (defn- issuer-metadata
   "The authorization-server metadata for `iss`.
 
-  Returns the cached entry, or fetches it from
-  <iss>/.well-known/oauth-authorization-server, validates that the metadata's
-  issuer matches, and caches it. Makes refresh/revoke work after a process
-  restart, when the in-memory issuer cache is empty."
+  Returns the cached entry (fresh for `issuer-metadata-ttl`), or fetches it
+  from <iss>/.well-known/oauth-authorization-server, validates that the
+  metadata's issuer matches, and caches it. Makes refresh/revoke/callback
+  work after a process restart, when the in-memory issuer cache is empty."
   [client iss cb]
   (if-let [metadata (get-issuer client iss)]
     (cb metadata)
@@ -418,7 +425,6 @@
 
   Return a map with:
   :state    The local state stored for this session.
-  :issuer   The issuer for this request.
   :error    In case of an error."
   [client {:keys [response iss state error code] :as params}]
   (let [saved-state (store/get (:state-store client) state)]
@@ -443,8 +449,7 @@
                :state saved-state}
 
               :else
-              {:state saved-state
-               :issuer (get-issuer client iss)})))))
+              {:state saved-state})))))
 
 (defn callback
   "Exchange the authorization code for OAuth tokens and return a OAuth session.
@@ -459,43 +464,76 @@
   :state    The app state passed in authorize, if any."
   [client params & {:as opts}]
   (let [[cb val] (i/platform-async opts)
-        {:keys [error state issuer] :as resp} (validate-callback-params client params)]
+        {:keys [error state] :as resp} (validate-callback-params client params)]
     (if error
       (cb resp)
-      (let [{:keys [verifier dpop-key app-state identity]} state
-            server {:issuer issuer
-                    :dpop-key dpop-key}]
-        (exchange-code client server {:code (:code params)
-                                      :verifier verifier}
-                       (fn [{:keys [error] :as resp}]
-                         (if error
-                           (cb resp)
-                           (let [did (:sub resp)
-                                 iss (:issuer issuer)
-                                 session-data (merge identity
-                                                     {:did did
-                                                      :iss iss
-                                                      :tokens (tokens+expiry iss (:aud resp) resp)
-                                                      :dpop-key dpop-key})
-                                 store-session! (fn []
-                                                  (store/set (:session-store client) did session-data)
-                                                  (cb (cond-> {:session (oauth-session client session-data)}
-                                                        app-state (assoc :state app-state))))]
-                             ;; revoke any pre-existing session for the same DID
-                             (if-let [existing (store/get (:session-store client) did)]
-                               (revoke-tokens client existing (fn [_] (store-session!)))
-                               (store-session!))))))))
+      (let [{:keys [verifier dpop-key app-state identity]} state]
+        (issuer-metadata
+         client (:iss state)
+         (fn [{:keys [error] :as issuer}]
+           (if error
+             (cb issuer)
+             (let [server {:issuer issuer
+                           :dpop-key dpop-key}]
+               (exchange-code client server {:code (:code params)
+                                             :verifier verifier}
+                              (fn [{:keys [error] :as resp}]
+                                (if error
+                                  (cb resp)
+                                  (let [did (:sub resp)
+                                        iss (:issuer issuer)
+                                        session-data (merge identity
+                                                            {:did did
+                                                             :iss iss
+                                                             :tokens (tokens+expiry iss (:aud resp) resp)
+                                                             :dpop-key dpop-key})
+                                        store-session! (fn []
+                                                         (store/set (:session-store client) did session-data)
+                                                         (cb (cond-> {:session (oauth-session client session-data)}
+                                                               app-state (assoc :state app-state))))]
+                                    ;; revoke any pre-existing session for the same DID
+                                    (if-let [existing (store/get (:session-store client) did)]
+                                      (revoke-tokens client existing (fn [_] (store-session!)))
+                                      (store-session!))))))))))))
     val))
+
+;; Tokens are considered stale this many seconds before :expires-at, plus a
+;; random jitter to spread refreshes across concurrent instances.
+(def token-expiry-leeway 10)
+(def token-expiry-jitter 30)
+
+(defn- stale-tokens?
+  "True when these tokens are expired or about to expire. Tokens without
+  :expires-at (legacy rows) are never considered stale."
+  [{:keys [expires-at]}]
+  (boolean
+   (and expires-at
+        (< expires-at (+ (crypto/now)
+                         token-expiry-leeway
+                         (rand-int token-expiry-jitter))))))
 
 (defn restore
   "The OAuth session for this did.
 
   Resolves to the session or {:error \"SessionNotFound\" :did did}.
-  Tolerates legacy stored sessions without :iss/:expires-at."
-  [client did & {:as opts}]
-  (let [[cb val] (i/platform-async opts)]
+
+  The :refresh option controls token freshness:
+  :auto (default)  refresh first when the stored tokens are expired or about
+                   to expire (see `stale-tokens?`)
+  true             always refresh first
+  false            return the stored tokens as-is, even if expired
+
+  Tolerates legacy stored sessions without :iss/:expires-at (never refreshed
+  proactively, only on an invalid-token response)."
+  [client did & {:keys [refresh] :or {refresh :auto} :as opts}]
+  (let [[cb val] (i/platform-async (dissoc opts :refresh))]
     (if-let [session-data (store/get (:session-store client) did)]
-      (cb (oauth-session client session-data))
+      (if (case refresh
+            true true
+            false false
+            (stale-tokens? (:tokens session-data)))
+        (refresh-session client {:did did} cb)
+        (cb (oauth-session client session-data)))
       (cb {:error "SessionNotFound" :did did}))
     val))
 
@@ -524,15 +562,17 @@
                (store/del session-store did))
              (cb {:error "TokenRefreshError"
                   :message (or error_description "The refresh token grant was rejected.")
-                  :did did})))))))
+                  :did did
+                  ::xrpc-client/session-expired? true})))))))
 
 (defn- run-refresh
   "Perform the refresh_token grant for the stored session of this DID.
 
   cb receives a new session (satisfying xrpc-client/Session) or {:error ...}.
-  Definitive failures delete the stored session; transient failures (network,
-  5xx) leave it in place. The refreshed tokens are persisted via store/set
-  before the new session is delivered."
+  Definitive failures delete the stored session and are tagged with
+  :atproto.xrpc.client/session-expired? so XRPC clients drop the dead session;
+  transient failures (network, 5xx) leave it in place. The refreshed tokens
+  are persisted via store/set before the new session is delivered."
   [client did cb]
   (let [session-store (:session-store client)
         stored (store/get session-store did)]
@@ -540,13 +580,15 @@
       (not stored)
       (cb {:error "TokenRefreshError"
            :message "Session deleted."
-           :did did})
+           :did did
+           ::xrpc-client/session-expired? true})
 
       (not (get-in stored [:tokens :refresh_token]))
       (do (store/del session-store did)
           (cb {:error "TokenRefreshError"
                :message "No refresh token available."
-               :did did}))
+               :did did
+               ::xrpc-client/session-expired? true}))
 
       :else
       ;; Re-verify the issuer for this DID before using the refresh token.
@@ -561,7 +603,8 @@
                    (do (store/del session-store did)
                        (cb {:error "TokenRefreshError"
                             :message "Issuer mismatch."
-                            :did did}))
+                            :did did
+                            ::xrpc-client/session-expired? true}))
 
                    :else
                    (let [iss (or (:iss stored) iss)
@@ -579,10 +622,12 @@
                            (fn [{:keys [error] :as token-resp}]
                              (cond
                                (not error)
+                               ;; pin :sub to the session's DID; the token
+                               ;; response's sub is not re-validated here
                                (let [session-data (merge stored
                                                          {:iss iss
                                                           :did-doc (:did-doc identity)
-                                                          :tokens (tokens+expiry iss aud (update token-resp :sub #(or % did)))}
+                                                          :tokens (tokens+expiry iss aud (assoc token-resp :sub did))}
                                                          (when (:handle identity)
                                                            {:handle (:handle identity)}))]
                                  (store/set session-store did session-data)

--- a/src/atproto/oauth/client.cljc
+++ b/src/atproto/oauth/client.cljc
@@ -14,8 +14,31 @@
             [atproto.oauth.client.dpop :as dpop]
             [atproto.oauth.client.store :as store]))
 
-;; todo:
-;; - implement (auto-)refresh
+;; -----------------------------------------------------------------------------
+;; Persisted session shape
+;; -----------------------------------------------------------------------------
+
+;; The session-store value (JSON, key = DID). Readers must tolerate legacy
+;; rows missing :iss and :tokens/:expires-at.
+
+(s/def ::did string?)
+(s/def ::handle string?)
+(s/def ::did-doc map?)
+(s/def ::dpop-key map?)
+(s/def ::iss ::http/url)
+(s/def ::access_token string?)
+(s/def ::refresh_token string?)
+(s/def ::token_type string?)
+(s/def ::scope string?)
+(s/def ::sub string?)
+(s/def ::aud string?)
+(s/def ::expires-at int?)
+(s/def ::tokens
+  (s/keys :req-un [::access_token ::token_type]
+          :opt-un [::refresh_token ::scope ::sub ::aud ::iss ::expires-at]))
+(s/def ::session-data
+  (s/keys :req-un [::did ::tokens ::dpop-key]
+          :opt-un [::iss ::handle ::did-doc]))
 
 ;; -----------------------------------------------------------------------------
 ;; OAuth session for the XRPC client
@@ -55,6 +78,9 @@
 ;; atproto clients and servers must support ES256
 (def default-alg "ES256")
 
+;; Maximum age of a pending-authorization state entry, in seconds.
+(def state-max-age (* 60 60))
+
 (defn create
   "Create a new OAuth2 client."
   [{:keys [client-metadata keys state-store session-store] :as opts}]
@@ -66,6 +92,8 @@
                              :jwks (jwt/public-jwks jwks))
      :jwks jwks
      :issuers (atom {})
+     ;; per-DID single-flight token refreshes
+     ::refresh-inflight (atom {})
      :state-store (or state-store (store/memory-store))
      :session-store (or session-store (store/memory-store))}))
 
@@ -76,6 +104,13 @@
 (defn- get-issuer
   [client iss]
   (get @(:issuers client) iss))
+
+(defn- after-delay
+  "Invoke f after ms milliseconds, off the calling thread."
+  [ms f]
+  #?(:clj (future (Thread/sleep (long ms)) (f))
+     :cljs (js/setTimeout f ms))
+  nil)
 
 ;; Resolve identity
 
@@ -98,6 +133,31 @@
                          http/client-interceptor]}
              :callback (fn [{:keys [error body] :as resp}]
                          (cb (if error resp body)))))
+
+(defn- issuer-metadata
+  "The authorization-server metadata for `iss`.
+
+  Returns the cached entry, or fetches it from
+  <iss>/.well-known/oauth-authorization-server, validates that the metadata's
+  issuer matches, and caches it. Makes refresh/revoke work after a process
+  restart, when the in-memory issuer cache is empty."
+  [client iss cb]
+  (if-let [metadata (get-issuer client iss)]
+    (cb metadata)
+    (fetch-asmd iss
+                (fn [{:keys [error] :as resp}]
+                  (cond
+                    error
+                    (cb resp)
+
+                    (not (= iss (:issuer resp)))
+                    (cb {:error "IssuerMismatch"
+                         :message "Authorization server metadata does not match the issuer URL."
+                         :iss iss})
+
+                    :else
+                    (do (set-issuer! client iss resp)
+                        (cb resp)))))))
 
 (defn- handle-asmd
   [client {:keys [rsmd asmd identity] :as ctx} cb]
@@ -145,7 +205,7 @@
                                  (cb resp)
                                  (handle-identity client {:identity resp} cb)))))
 
-;; Pushed Authorization Request
+;; Authorization server requests
 
 (defmulti client-auth
   "The authentication payload for this client and issuer."
@@ -174,6 +234,68 @@
                                       :jti (crypto/generate-nonce 16)
                                       :iat (crypto/now)})}))
 
+(defn- as-request
+  "POST `params`, merged with this client's authentication payload, to one of
+  the issuer's endpoints (e.g. :token_endpoint), DPoP-signed with `dpop-key`.
+
+  cb receives the parsed response body or an {:error ...} map; OAuth error
+  bodies pass through as e.g. {:error \"invalid_grant\" ...}."
+  [client {:keys [issuer dpop-key]} endpoint params cb]
+  (let [{:keys [client_id]} (:client-metadata client)]
+    (if-let [url (get issuer endpoint)]
+      (i/execute {::i/request {:method :post
+                               :url url
+                               :headers {:content-type "application/json"}
+                               :body (merge params (client-auth client issuer))}
+                  ::i/queue [(dpop/interceptor {:iss client_id
+                                                :dpop-key dpop-key})
+                             json/client-interceptor
+                             http/client-interceptor]}
+                 :callback
+                 (fn [{:keys [error status body] :as http-response}]
+                   (cond
+                     error                        (cb http-response)
+                     (:error body)                (cb body)
+                     (not (http/success? status)) (cb (http/error-map http-response))
+                     :else                        (cb body))))
+      (cb {:error "MissingEndpoint"
+           :message (str "No " (name endpoint) " in the authorization server metadata.")
+           :endpoint endpoint}))))
+
+(defn- token-request
+  "POST `params` to the issuer's token endpoint. See `as-request`."
+  [client server params cb]
+  (as-request client server :token_endpoint params cb))
+
+(defn- tokens+expiry
+  "Normalize a token response into the token map persisted in the session
+  store: keep access_token/refresh_token/token_type/scope/sub, add :iss and
+  :aud, compute :expires-at (epoch seconds) from :expires_in."
+  [iss aud {:keys [expires_in] :as token-response}]
+  (cond-> (-> token-response
+              (select-keys [:access_token :refresh_token :token_type :scope :sub])
+              (assoc :iss iss :aud aud))
+    expires_in (assoc :expires-at (+ (crypto/now) expires_in))))
+
+(defn- revoke-tokens
+  "Best-effort revocation of this session's access token at the authorization
+  server. All failures (missing issuer metadata, no revocation endpoint,
+  network or server errors) are swallowed; cb is always called with nil."
+  [client {:keys [iss dpop-key tokens]} cb]
+  (if-not iss
+    (cb nil)
+    (issuer-metadata client iss
+                     (fn [{:keys [error revocation_endpoint] :as issuer}]
+                       (if (or error (not revocation_endpoint))
+                         (cb nil)
+                         (as-request client
+                                     {:issuer issuer :dpop-key dpop-key}
+                                     :revocation_endpoint
+                                     {:token (:access_token tokens)}
+                                     (fn [_] (cb nil))))))))
+
+;; Pushed Authorization Request
+
 (defn- par-interceptor
   "Interceptor for this client to send the push authorization request (PAR) to this issuer."
   [{:keys [client-metadata] :as client}
@@ -187,6 +309,7 @@
                          (fn [{:keys [opts identity input]}]
                            (let [pkce (crypto/generate-pkce 63)
                                  state (crypto/generate-nonce 16)
+                                 now (crypto/now)
                                  oauth-params (cond-> {:client_id client_id
                                                        :redirect_uri (or (:redirect-uri opts)
                                                                          (first redirect_uris))
@@ -203,7 +326,9 @@
                                          :dpop-key dpop-key
                                          :identity identity
                                          :verifier (:verifier pkce)
-                                         :app-state (:state opts)})
+                                         :app-state (:state opts)
+                                         :created-at now
+                                         :expires-at (+ now state-max-age)})
                              {:method :post
                               :url pushed_authorization_request_endpoint
                               :headers {:content-type "application/json"}
@@ -264,45 +389,29 @@
 (defn- exchange-code
   "Exchange an authorization code for a set of tokens."
   [client server {:keys [code verifier]} cb]
-  (let [{:keys [client_id redirect_uris]} (:client-metadata client)
-        {:keys [issuer dpop-key]} server
-        {:keys [token_endpoint]} issuer]
-    (i/execute {::i/request {:method :post
-                             :url token_endpoint
-                             :headers {:content-type "application/json"}
-                             :body (merge {:grant_type "authorization_code"
-                                           :redirect_uri (first redirect_uris)
-                                           :code code
-                                           :code_verifier verifier}
-                                          (client-auth client issuer))
-                             :dpop-key dpop-key}
-                ::i/queue [(dpop/interceptor {:iss client_id
-                                              :dpop-key dpop-key})
-                           json/client-interceptor
-                           http/client-interceptor]}
-               :callback
-               (fn [{:keys [error status body] :as http-response}]
-                 (cond
-                   error
-                   (cb http-response)
-
-                   (:error body)
-                   (cb body)
-
-                   :else
-                   ;; The token response must be valid before the 'sub' it contains can be trusted
-                   (resolve client
-                            (:sub body)
-                            (fn [{:keys [error iss] :as resp}]
-                              (cb (cond
-                                    error resp
-                                    (not (= iss (:issuer issuer))) {:error "Issuer mismatch."}
-                                    :else (assoc body
-                                                 :aud
-                                                 (-> resp
-                                                     :identity
-                                                     :did-doc
-                                                     identity/did-doc-pds)))))))))))
+  (let [{:keys [redirect_uris]} (:client-metadata client)
+        {:keys [issuer]} server]
+    (token-request client server
+                   {:grant_type "authorization_code"
+                    :redirect_uri (first redirect_uris)
+                    :code code
+                    :code_verifier verifier}
+                   (fn [{:keys [error] :as body}]
+                     (if error
+                       (cb body)
+                       ;; The token response must be valid before the 'sub' it contains can be trusted
+                       (resolve client
+                                (:sub body)
+                                (fn [{:keys [error iss] :as resp}]
+                                  (cb (cond
+                                        error resp
+                                        (not (= iss (:issuer issuer))) {:error "Issuer mismatch."}
+                                        :else (assoc body
+                                                     :aud
+                                                     (-> resp
+                                                         :identity
+                                                         :did-doc
+                                                         identity/did-doc-pds)))))))))))
 
 (defn- validate-callback-params
   "Validate the callback params.
@@ -322,6 +431,12 @@
                :params params
                :state saved-state}
 
+              (and (:created-at saved-state)
+                   (< state-max-age (- (crypto/now) (:created-at saved-state))))
+              {:error "StateExpired"
+               :params params
+               :state saved-state}
+
               (not (= iss (:iss saved-state)))
               {:error "Issuer mismatch."
                :params params
@@ -333,6 +448,11 @@
 
 (defn callback
   "Exchange the authorization code for OAuth tokens and return a OAuth session.
+
+  Stores :iss and :tokens (with :expires-at) in the session store, revoking
+  any pre-existing session for the same DID before storing the new one.
+  State entries older than `state-max-age` are rejected as
+  {:error \"StateExpired\"} and deleted.
 
   Return a map with:
   :session  The OAuth session.
@@ -351,24 +471,178 @@
                          (if error
                            (cb resp)
                            (let [did (:sub resp)
-                                 session (merge identity
-                                                {:did did
-                                                 :tokens resp
-                                                 :dpop-key dpop-key})]
-                             (store/set (:session-store client) did session)
-                             (cb (cond-> {:session (oauth-session client session)}
-                                   app-state (assoc :state app-state)))))))))
-
+                                 iss (:issuer issuer)
+                                 session-data (merge identity
+                                                     {:did did
+                                                      :iss iss
+                                                      :tokens (tokens+expiry iss (:aud resp) resp)
+                                                      :dpop-key dpop-key})
+                                 store-session! (fn []
+                                                  (store/set (:session-store client) did session-data)
+                                                  (cb (cond-> {:session (oauth-session client session-data)}
+                                                        app-state (assoc :state app-state))))]
+                             ;; revoke any pre-existing session for the same DID
+                             (if-let [existing (store/get (:session-store client) did)]
+                               (revoke-tokens client existing (fn [_] (store-session!)))
+                               (store-session!))))))))
     val))
 
 (defn restore
-  "The OAuth session for this did, or nil."
+  "The OAuth session for this did.
+
+  Resolves to the session or {:error \"SessionNotFound\" :did did}.
+  Tolerates legacy stored sessions without :iss/:expires-at."
   [client did & {:as opts}]
   (let [[cb val] (i/platform-async opts)]
-    (when-let [session-data (store/get (:session-store client) did)]
-      (cb (oauth-session client session-data)))
+    (if-let [session-data (store/get (:session-store client) did)]
+      (cb (oauth-session client session-data))
+      (cb {:error "SessionNotFound" :did did}))
     val))
 
-(defn refresh-session
-  [client session cb]
-  'todo)
+;; -----------------------------------------------------------------------------
+;; Refresh
+;; -----------------------------------------------------------------------------
+
+(defn- recover-invalid-grant
+  "Concurrency recovery for a refresh_token grant rejected with invalid_grant.
+
+  Another process may have used (and rotated) the refresh token first: wait a
+  moment, re-read the store, and adopt the stored session if it now holds
+  different tokens. Otherwise the grant is dead: delete the session and report
+  a TokenRefreshError."
+  [client did used-tokens {:keys [error_description] :as token-resp} cb]
+  (after-delay
+   1000
+   (fn []
+     (let [session-store (:session-store client)
+           stored (store/get session-store did)]
+       (if (and stored
+                (not= (select-keys (:tokens stored) [:access_token :refresh_token])
+                      (select-keys used-tokens [:access_token :refresh_token])))
+         (cb (oauth-session client stored))
+         (do (when stored
+               (store/del session-store did))
+             (cb {:error "TokenRefreshError"
+                  :message (or error_description "The refresh token grant was rejected.")
+                  :did did})))))))
+
+(defn- run-refresh
+  "Perform the refresh_token grant for the stored session of this DID.
+
+  cb receives a new session (satisfying xrpc-client/Session) or {:error ...}.
+  Definitive failures delete the stored session; transient failures (network,
+  5xx) leave it in place. The refreshed tokens are persisted via store/set
+  before the new session is delivered."
+  [client did cb]
+  (let [session-store (:session-store client)
+        stored (store/get session-store did)]
+    (cond
+      (not stored)
+      (cb {:error "TokenRefreshError"
+           :message "Session deleted."
+           :did did})
+
+      (not (get-in stored [:tokens :refresh_token]))
+      (do (store/del session-store did)
+          (cb {:error "TokenRefreshError"
+               :message "No refresh token available."
+               :did did}))
+
+      :else
+      ;; Re-verify the issuer for this DID before using the refresh token.
+      (resolve client did
+               (fn [{:keys [error identity iss] :as resp}]
+                 (cond
+                   error
+                   (cb resp)
+
+                   ;; legacy rows have no :iss; adopt the resolved issuer
+                   (and (:iss stored) (not (= iss (:iss stored))))
+                   (do (store/del session-store did)
+                       (cb {:error "TokenRefreshError"
+                            :message "Issuer mismatch."
+                            :did did}))
+
+                   :else
+                   (let [iss (or (:iss stored) iss)
+                         aud (identity/did-doc-pds (:did-doc identity))]
+                     (issuer-metadata
+                      client iss
+                      (fn [{:keys [error] :as issuer}]
+                        (if error
+                          (cb issuer)
+                          (token-request
+                           client
+                           {:issuer issuer :dpop-key (:dpop-key stored)}
+                           {:grant_type "refresh_token"
+                            :refresh_token (get-in stored [:tokens :refresh_token])}
+                           (fn [{:keys [error] :as token-resp}]
+                             (cond
+                               (not error)
+                               (let [session-data (merge stored
+                                                         {:iss iss
+                                                          :did-doc (:did-doc identity)
+                                                          :tokens (tokens+expiry iss aud (update token-resp :sub #(or % did)))}
+                                                         (when (:handle identity)
+                                                           {:handle (:handle identity)}))]
+                                 (store/set session-store did session-data)
+                                 (cb (oauth-session client session-data)))
+
+                               (= "invalid_grant" error)
+                               (recover-invalid-grant client did (:tokens stored) token-resp cb)
+
+                               :else
+                               (cb token-resp))))))))))))))
+
+(defn- refresh-session
+  "xrpc-client/Session refresh for OAuth sessions (wired in oauth-session
+  metadata).
+
+  Single-flighted per DID: concurrent refreshes for one DID across XRPC
+  clients sharing this OAuth client result in a single token request, with
+  every caller receiving the same result."
+  [client {:keys [did]} cb]
+  (let [inflight (::refresh-inflight client)
+        [prev _] (swap-vals! inflight
+                             (fn [m]
+                               (if (contains? m did)
+                                 (update m did conj cb)
+                                 (assoc m did [cb]))))]
+    (when (not (contains? prev did))
+      (run-refresh client did
+                   (fn [result]
+                     (let [[m _] (swap-vals! inflight dissoc did)]
+                       (run! #(% result) (get m did))))))))
+
+(defn refresh
+  "Force-refresh the stored OAuth session for this DID.
+
+  Async; resolves to the refreshed session or an {:error ...} map."
+  [client did & {:as opts}]
+  (let [[cb val] (i/platform-async opts)]
+    (if (store/get (:session-store client) did)
+      (refresh-session client {:did did} cb)
+      (cb {:error "SessionNotFound" :did did}))
+    val))
+
+;; -----------------------------------------------------------------------------
+;; Revocation
+;; -----------------------------------------------------------------------------
+
+(defn revoke
+  "Sign out: best-effort token revocation at the authorization server, then
+  delete the stored session. The local session is deleted even when the
+  server-side revocation fails.
+
+  Async; resolves to {:did did :revoked true} when a stored session was
+  deleted, {:did did :revoked false} when there was none."
+  [client did & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        session-store (:session-store client)]
+    (if-let [session-data (store/get session-store did)]
+      (revoke-tokens client session-data
+                     (fn [_]
+                       (store/del session-store did)
+                       (cb {:did did :revoked true})))
+      (cb {:did did :revoked false}))
+    val))

--- a/src/atproto/oauth/client/store.clj
+++ b/src/atproto/oauth/client/store.clj
@@ -1,26 +1,61 @@
 (ns atproto.oauth.client.store
   (:refer-clojure :exclude [get set])
-  (:require [atproto.runtime.json :as json]))
+  (:require [atproto.runtime.json :as json]
+            [atproto.runtime.crypto :as crypto]))
 
-;; todo: should we make this async?
 (defprotocol Store
-  "Interface for stores needed by the OAuth 2 client."
+  "Interface for the key/value stores needed by the OAuth 2 client.
+
+  Implementations are synchronous; values are JSON strings.
+
+  Pending-authorization state entries are short-lived: the client stamps
+  :created-at/:expires-at (epoch seconds) into state values and rejects
+  entries older than one hour, so implementations do not need to expire rows
+  for correctness — but they should delete state rows older than an hour to
+  avoid unbounded growth from abandoned authorization flows."
   (get* [_ key] "The value for key, or nil.")
   (set* [_ key val] "Set the value for key.")
   (del* [_ key] "Delete the value for key."))
 
+(defn- entry-expires-at
+  "The expiry (epoch seconds) declared by this JSON value, if any."
+  [val]
+  (try
+    (let [expires-at (:expires-at (json/read-str val))]
+      (when (int? expires-at)
+        expires-at))
+    (catch Exception _)))
+
 (defn memory-store
+  "In-memory store.
+
+  Values written with a top-level :expires-at field (epoch seconds) are
+  treated as expired after that time: they are lazily evicted on reads and
+  writes and never returned. Values without :expires-at (e.g. sessions) are
+  kept forever."
   ([] (memory-store (atom {})))
   ([store-atom]
-   (reify Store
-     (get* [_ key]
-       (@store-atom key))
-     (set* [_ key val]
-       (swap! store-atom assoc key val)
-       nil)
-     (del* [_ key]
-       (swap! store-atom dissoc key)
-       nil))))
+   (letfn [(expired? [entry now]
+             (when-let [expires-at (:expires-at entry)]
+               (<= expires-at now)))]
+     (reify Store
+       (get* [_ key]
+         (when-let [entry (clojure.core/get @store-atom key)]
+           (if (expired? entry (crypto/now))
+             (do (swap! store-atom dissoc key)
+                 nil)
+             (:val entry))))
+       (set* [_ key val]
+         (let [now (crypto/now)
+               entry {:val val :expires-at (entry-expires-at val)}]
+           (swap! store-atom
+                  (fn [m]
+                    (-> (into {} (remove (fn [[_ e]] (expired? e now))) m)
+                        (assoc key entry))))
+           nil))
+       (del* [_ key]
+         (swap! store-atom dissoc key)
+         nil)))))
 
 (defn get
   [store key]

--- a/src/atproto/xrpc/client.cljc
+++ b/src/atproto/xrpc/client.cljc
@@ -1,6 +1,7 @@
 (ns atproto.xrpc.client
   "Cross-platform XRPC client for AT Proto."
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
             [atproto.runtime.http :as http]
             [atproto.runtime.json :as json]
             [atproto.runtime.interceptor :as i]
@@ -16,13 +17,18 @@
 ;; - consider bubbling up server error in the response map
 
 (defn init
-  "Initialize a new XRPC client and return it."
+  "Initialize a new XRPC client and return it.
+
+  config keys: :service, :session, :validate-requests?. The returned client
+  also carries ::refresh-state (atom) used to single-flight token refreshes.
+  Throws if neither :service nor :session is provided."
   [{:keys [service session validate-requests?] :as config}]
   (if (and (not service) (not session))
     (throw (ex-info "A service or a session is required." config))
     {:service (or service (:pds session))
      :session (when session (atom session))
-     :validate-requests? (boolean validate-requests?)}))
+     :validate-requests? (boolean validate-requests?)
+     ::refresh-state (atom nil)}))
 
 (defn request-validator
   [{:keys [validate-requests?]}]
@@ -37,34 +43,114 @@
 
 (defprotocol Session
   :extend-via-metadata true
-  (auth-interceptor [session] "Interceptor to authenticate HTTP requests.")
-  (refresh-token [session cb] "Refresh the token."))
+  (auth-interceptor [session]
+    "Interceptor to authenticate HTTP requests.")
+  (refresh-token [session cb]
+    "Refresh the session's tokens.
 
-(defn expired-token-error?
-  [{:keys [headers body]}]
-  (and (= "application/json" (:content-type headers))
-       (= "ExpiredToken" (:error body))))
+     MUST eventually call cb exactly once with either a NEW session value
+     (satisfying Session, with refreshed tokens) or an {:error ...} map.
+     Implementations must never throw out of the calling thread without
+     invoking cb."))
+
+(defn invalid-token-response?
+  "True if this HTTP response indicates the access token was rejected and a
+  refresh should be attempted. Matches:
+  - 400 with a JSON body (content-type prefix \"application/json\") whose
+    :error is \"ExpiredToken\"
+  - 401 with no WWW-Authenticate header (bearer-auth convention)
+  - 401 whose WWW-Authenticate starts with \"Bearer \" or \"DPoP \" and
+    contains error=\"invalid_token\" (RFC 6750/9449)."
+  [{:keys [error status headers body] :as http-response}]
+  (boolean
+   (and (not error)
+        (case status
+          400 (and (some-> (:content-type headers)
+                           (str/starts-with? "application/json"))
+                   (= "ExpiredToken" (:error body)))
+          401 (let [www-authenticate (:www-authenticate headers)]
+                (or (nil? www-authenticate)
+                    (and (or (str/starts-with? www-authenticate "Bearer ")
+                             (str/starts-with? www-authenticate "DPoP "))
+                         (str/includes? www-authenticate "error=\"invalid_token\""))))
+          false))))
+
+(defn ^:deprecated expired-token-error?
+  "Deprecated alias of `invalid-token-response?`."
+  [http-response]
+  (invalid-token-response? http-response))
+
+(defn- single-flight-refresh!
+  "Join the client's single-flight token refresh.
+
+  cb is invoked exactly once with the refresh result: a new session value or
+  an {:error ...} map. The first caller triggers the session's refresh-token;
+  callers that arrive while a refresh is in flight queue on its result. On
+  success the client's session atom is reset to the new session before any
+  waiter is invoked."
+  [{:keys [session ::refresh-state]} cb]
+  (let [[prev _] (swap-vals! refresh-state
+                             (fn [state]
+                               (if state
+                                 (update state :waiters conj cb)
+                                 {:waiters [cb]})))]
+    (when (nil? prev)
+      (let [delivered? (atom false)
+            deliver! (fn [result]
+                       (when (compare-and-set! delivered? false true)
+                         (let [[{:keys [waiters]} _] (swap-vals! refresh-state
+                                                                (constantly nil))]
+                           (when-not (:error result)
+                             (reset! session result))
+                           (run! #(% result) waiters))))]
+        (try
+          (refresh-token @session deliver!)
+          (catch #?(:clj Throwable :cljs :default) t
+            (deliver! {:error "TokenRefreshError"
+                       :message (ex-message t)
+                       :exception t})))))))
 
 (defn delegate-auth-interceptor
-  "Delegate authentication to the session, if any."
+  "Delegate authentication to the session, if any.
+
+  ::i/enter snapshots the pristine context under ::original-ctx and conses
+  the session's auth interceptor onto the queue.
+
+  ::i/leave, when the response indicates the access token was rejected
+  (see `invalid-token-response?`), the session is not itself a refresh client
+  (:refresh?), and this request has not already been retried (::auth-retried?):
+  joins the client's single-flight refresh (::refresh-state), then either
+  retries the pristine request once with a fresh auth interceptor from the
+  new session, or continues with the full {:error ...} map from the refresh
+  callback as the response. A retried request that fails again with an
+  invalid-token response is returned to the caller as-is (no second refresh).
+  The leave fn returns nil after handing off to i/continue."
   [{:keys [session] :as client}]
-  {::i/name ::delegate-auth-interceptor
-   ::i/enter (fn [ctx]
-               (if session
-                 (update ctx ::i/queue #(cons (auth-interceptor @session) %))
-                 ctx))
-   ::i/leave (fn [ctx]
-               (if (and session
-                        (expired-token-error? (::i/response ctx))
-                        (not (:refresh? @session)))
-                 (refresh-token @session
-                                (fn [{:keys [error] :as new-session}]
-                                  (if error
-                                    (i/continue (assoc ctx ::i/response error))
-                                    (do
-                                      (reset! session new-session)
-                                      (i/continue (dissoc ctx ::i/response))))))
-                 ctx))})
+  (let [wrap-auth (fn [ctx]
+                    (-> ctx
+                        (assoc ::original-ctx ctx)
+                        (update ::i/queue #(cons (auth-interceptor @session) %))))]
+    {::i/name ::delegate-auth-interceptor
+     ::i/enter (fn [ctx]
+                 (if session
+                   (wrap-auth ctx)
+                   ctx))
+     ::i/leave (fn [{:keys [::i/response ::original-ctx] :as ctx}]
+                 (if (and session
+                          (invalid-token-response? response)
+                          (not (:refresh? @session))
+                          (not (::auth-retried? ctx)))
+                   (do (single-flight-refresh!
+                        client
+                        (fn [{:keys [error] :as result}]
+                          (if error
+                            (i/continue (-> ctx
+                                            (dissoc ::original-ctx)
+                                            (assoc ::i/response result)))
+                            (i/continue (wrap-auth (assoc original-ctx
+                                                          ::auth-retried? true))))))
+                       nil)
+                   (dissoc ctx ::original-ctx ::auth-retried?)))}))
 
 (defn- url
   [{:keys [service]} nsid]
@@ -98,8 +184,9 @@
                        ::i/request
                        (fn [{:keys [nsid params encoding body] :as request}]
                          (let [encoding (or encoding
-                                            (and (coll? body) "application/json")
-                                            (throw (ex-info "Missing encoding" request)))]
+                                            (when (coll? body) "application/json"))]
+                           (when (and body (not encoding))
+                             (throw (ex-info "Missing encoding" request)))
                            (cond-> {:method :post
                                     :url (url client nsid)}
                              params (assoc :query-params (xrpc-params->query-params params))

--- a/src/atproto/xrpc/client.cljc
+++ b/src/atproto/xrpc/client.cljc
@@ -50,8 +50,11 @@
 
      MUST eventually call cb exactly once with either a NEW session value
      (satisfying Session, with refreshed tokens) or an {:error ...} map.
-     Implementations must never throw out of the calling thread without
-     invoking cb."))
+     Error maps may carry ::session-expired? true to signal that the session
+     is definitively dead (e.g. the server rejected the refresh token); the
+     client then drops its session and subsequent requests are sent
+     unauthenticated. Implementations must never throw out of the calling
+     thread without invoking cb."))
 
 (defn invalid-token-response?
   "True if this HTTP response indicates the access token was rejected and a
@@ -87,7 +90,8 @@
   an {:error ...} map. The first caller triggers the session's refresh-token;
   callers that arrive while a refresh is in flight queue on its result. On
   success the client's session atom is reset to the new session before any
-  waiter is invoked."
+  waiter is invoked; on an error carrying ::session-expired? the session atom
+  is reset to nil (the session is dropped)."
   [{:keys [session ::refresh-state]} cb]
   (let [[prev _] (swap-vals! refresh-state
                              (fn [state]
@@ -100,7 +104,9 @@
                        (when (compare-and-set! delivered? false true)
                          (let [[{:keys [waiters]} _] (swap-vals! refresh-state
                                                                 (constantly nil))]
-                           (when-not (:error result)
+                           (if (:error result)
+                             (when (::session-expired? result)
+                               (reset! session nil))
                              (reset! session result))
                            (run! #(% result) waiters))))]
         (try
@@ -124,7 +130,11 @@
   new session, or continues with the full {:error ...} map from the refresh
   callback as the response. A retried request that fails again with an
   invalid-token response is returned to the caller as-is (no second refresh).
-  The leave fn returns nil after handing off to i/continue."
+  The leave fn returns nil after handing off to i/continue.
+
+  A session dropped after a definitive refresh failure (see ::session-expired?
+  on `refresh-token`) leaves nil in the session atom: subsequent requests are
+  sent unauthenticated and no further refresh is attempted."
   [{:keys [session] :as client}]
   (let [wrap-auth (fn [ctx]
                     (-> ctx
@@ -132,11 +142,12 @@
                         (update ::i/queue #(cons (auth-interceptor @session) %))))]
     {::i/name ::delegate-auth-interceptor
      ::i/enter (fn [ctx]
-                 (if session
+                 (if (and session @session)
                    (wrap-auth ctx)
                    ctx))
      ::i/leave (fn [{:keys [::i/response ::original-ctx] :as ctx}]
                  (if (and session
+                          @session
                           (invalid-token-response? response)
                           (not (:refresh? @session))
                           (not (::auth-retried? ctx)))

--- a/test/atproto/credentials_test.cljc
+++ b/test/atproto/credentials_test.cljc
@@ -1,0 +1,141 @@
+(ns atproto.credentials-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [clojure.string :as str]
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.http :as http]
+            [atproto.test-support.http :as fake-http]
+            [atproto.xrpc.client :as xrpc-client]
+            [atproto.credentials :as credentials]))
+
+(def did "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa")
+
+(def did-doc
+  {:id did
+   :alsoKnownAs ["at://alice.test"]
+   :service [{:id "#atproto_pds"
+              :type "AtprotoPersonalDataServer"
+              :serviceEndpoint "https://pds.test"}]})
+
+(def create-session-response
+  (fake-http/json-response {:did did
+                            :didDoc did-doc
+                            :handle "alice.test"
+                            :accessJwt "access-1"
+                            :refreshJwt "refresh-1"}))
+
+(defn- bearer
+  [request]
+  (get-in request [:headers :authorization]))
+
+#?(:clj
+   (deftest create-test
+     (let [{:keys [handler]} (fake-http/routed
+                              [["plc.directory" (fake-http/json-response did-doc)]
+                               ["createSession" create-session-response]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)]
+           (is (nil? (:error session)))
+           (is (= {:accessJwt "access-1"
+                   :refreshJwt "refresh-1"
+                   :did did
+                   :pds "https://pds.test"
+                   :handle "alice.test"}
+                  session))
+           ;; satisfies the Session protocol via metadata
+           (is (map? (xrpc-client/auth-interceptor session))))))))
+
+#?(:clj
+   (deftest refresh-end-to-end-test
+     ;; an XRPC call rejected with ExpiredToken transparently refreshes via
+     ;; com.atproto.server.refreshSession and the retried call succeeds
+     (let [{:keys [handler requests]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["refreshSession" (fn [req]
+                                 (if (= "Bearer refresh-1" (bearer req))
+                                   ;; refreshSession output has no didDoc
+                                   (fake-http/json-response {:did did
+                                                             :handle "alice.test"
+                                                             :accessJwt "access-2"
+                                                             :refreshJwt "refresh-2"})
+                                   (fake-http/json-response 401 {:error "InvalidToken"})))]
+             [#(= "Bearer access-1" (bearer %))
+              (fake-http/json-response 400 {:error "ExpiredToken"})]
+             [#(= "Bearer access-2" (bearer %))
+              (fake-http/json-response {:ok true})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               xrpc (xrpc-client/init {:session session})
+               resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
+                                                        :body {:n 1}})
+                           2000 ::timeout)]
+           (is (= {:ok true} resp))
+           ;; the refresh request hit refreshSession with the refresh JWT
+           (let [refresh-request (first (filter #(str/includes? (:url %) "refreshSession")
+                                                @requests))]
+             (is (some? refresh-request))
+             (is (= :post (:method refresh-request)))
+             (is (= "Bearer refresh-1" (bearer refresh-request))))
+           ;; the rebuilt session has the new tokens and keeps :pds/:handle
+           (let [new-session @(:session xrpc)]
+             (is (= "access-2" (:accessJwt new-session)))
+             (is (= "refresh-2" (:refreshJwt new-session)))
+             (is (= "https://pds.test" (:pds new-session)))
+             (is (= "alice.test" (:handle new-session)))
+             (is (= did (:did new-session)))
+             (is (map? (xrpc-client/auth-interceptor new-session)))))))))
+
+#?(:clj
+   (deftest refresh-did-change-rejected-test
+     (let [{:keys [handler]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["refreshSession" (fake-http/json-response {:did "did:plc:bbbbbbbbbbbbbbbbbbbbbbbb"
+                                                         :handle "alice.test"
+                                                         :accessJwt "access-2"
+                                                         :refreshJwt "refresh-2"})]
+             ["" (fake-http/json-response 400 {:error "ExpiredToken"})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               xrpc (xrpc-client/init {:session session})
+               resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
+                                                        :body {:n 1}})
+                           2000 ::timeout)]
+           (is (= "InvalidDID" (:error resp))))))))
+
+#?(:clj
+   (deftest logout-test
+     (let [{:keys [handler requests]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["deleteSession" (fake-http/json-response {})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               resp (deref (credentials/logout session) 1000 ::timeout)]
+           (is (= {} resp))
+           (let [delete-request (first (filter #(str/includes? (:url %) "deleteSession")
+                                               @requests))]
+             (is (some? delete-request))
+             (is (= "Bearer refresh-1" (bearer delete-request)))))))))
+
+#?(:clj
+   (deftest logout-server-error-still-resolves-test
+     (let [{:keys [handler]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["deleteSession" (fake-http/json-response 400 {:error "InvalidRequest"})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               resp (deref (credentials/logout session) 1000 ::timeout)]
+           (is (not= ::timeout resp))
+           (is (= "InvalidRequest" (:error resp))))))))

--- a/test/atproto/credentials_test.cljc
+++ b/test/atproto/credentials_test.cljc
@@ -107,7 +107,49 @@
                resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
                                                         :body {:n 1}})
                            2000 ::timeout)]
-           (is (= "InvalidDID" (:error resp))))))))
+           (is (= "InvalidDID" (:error resp)))
+           ;; a DID change is definitive: the session is dropped
+           (is (nil? @(:session xrpc))))))))
+
+#?(:clj
+   (deftest refresh-definitive-failure-drops-session-test
+     ;; a refreshSession rejected with ExpiredToken means the session is dead:
+     ;; the error is delivered and the client drops its session
+     (let [{:keys [handler]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["refreshSession" (fake-http/json-response 400 {:error "ExpiredToken"})]
+             ["" (fake-http/json-response 400 {:error "ExpiredToken"})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               xrpc (xrpc-client/init {:session session})
+               resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
+                                                        :body {:n 1}})
+                           2000 ::timeout)]
+           (is (= "ExpiredToken" (:error resp)))
+           (is (nil? @(:session xrpc))))))))
+
+#?(:clj
+   (deftest refresh-network-failure-keeps-session-test
+     ;; a transient refresh failure leaves the session in place
+     (let [{:keys [handler]}
+           (fake-http/routed
+            [["plc.directory" (fake-http/json-response did-doc)]
+             ["createSession" create-session-response]
+             ["refreshSession" {:error "HTTPClientError"
+                                :message "connection refused"}]
+             ["" (fake-http/json-response 400 {:error "ExpiredToken"})]])]
+       (with-redefs [http/handle-request handler]
+         (let [session (deref (credentials/create {:identifier did :password "pw"})
+                              1000 ::timeout)
+               xrpc (xrpc-client/init {:session session})
+               resp (deref (xrpc-client/procedure xrpc {:nsid "com.example.ping"
+                                                        :body {:n 1}})
+                           2000 ::timeout)]
+           (is (= "HTTPClientError" (:error resp)))
+           (is (= "access-1" (:accessJwt @(:session xrpc)))))))))
 
 #?(:clj
    (deftest logout-test

--- a/test/atproto/oauth/client_test.clj
+++ b/test/atproto/oauth/client_test.clj
@@ -1,0 +1,339 @@
+(ns atproto.oauth.client-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.http :as http]
+            [atproto.runtime.json :as json]
+            [atproto.runtime.crypto :as crypto]
+            [atproto.test-support.http :as fake-http]
+            [atproto.xrpc.client :as xrpc-client]
+            [atproto.oauth.client :as oauth]
+            [atproto.oauth.client.dpop :as dpop]
+            [atproto.oauth.client.store :as store]))
+
+(def did "did:plc:bbbbbbbbbbbbbbbbbbbbbbbb")
+(def issuer "https://auth.test")
+(def pds "https://pds.test")
+
+(def did-doc
+  {:id did
+   :alsoKnownAs ["at://bob.test"]
+   :service [{:id "#atproto_pds"
+              :type "AtprotoPersonalDataServer"
+              :serviceEndpoint pds}]})
+
+(def asmd
+  {:issuer issuer
+   :token_endpoint (str issuer "/token")
+   :revocation_endpoint (str issuer "/revoke")
+   :pushed_authorization_request_endpoint (str issuer "/par")
+   :authorization_endpoint (str issuer "/authorize")
+   :require_pushed_authorization_requests true
+   :token_endpoint_auth_methods_supported ["none"]})
+
+(def rsmd
+  {:resource pds
+   :authorization_servers [issuer]})
+
+(defn- test-client
+  []
+  (oauth/create {:client-metadata {:client_id "https://app.test/client-metadata.json"
+                                   :redirect_uris ["https://app.test/oauth/callback"]
+                                   :scope "atproto"}}))
+
+(defn- seed-session!
+  "Store a session for `did` and return the session data (with the dpop-key)."
+  [client & [overrides]]
+  (let [dpop-key (dpop/generate-key)
+        session-data (merge {:did did
+                             :handle "bob.test"
+                             :did-doc did-doc
+                             :iss issuer
+                             :dpop-key dpop-key
+                             :tokens {:access_token "at-1"
+                                      :refresh_token "rt-1"
+                                      :token_type "DPoP"
+                                      :scope "atproto"
+                                      :sub did
+                                      :aud pds
+                                      :iss issuer
+                                      :expires-at 0}}
+                            overrides)]
+    (store/set (:session-store client) did session-data)
+    session-data))
+
+(def resolution-routes
+  [["plc.directory" (fake-http/json-response did-doc)]
+   ["/.well-known/oauth-protected-resource" (fake-http/json-response rsmd)]
+   ["/.well-known/oauth-authorization-server" (fake-http/json-response asmd)]])
+
+(def token-success-response
+  (fake-http/json-response {:access_token "at-2"
+                            :refresh_token "rt-2"
+                            :token_type "DPoP"
+                            :scope "atproto"
+                            :sub did
+                            :expires_in 300}))
+
+(defn- requests-to
+  [requests url-fragment]
+  (filter #(str/includes? (:url %) url-fragment) @requests))
+
+(deftest refresh-end-to-end-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/token" token-success-response]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/refresh client did) 5000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= "at-2" (get-in session [:tokens :access_token])))
+        (is (= did (:did session)))
+        (is (= pds (:pds session)))
+        ;; satisfies the Session protocol
+        (is (map? (xrpc-client/auth-interceptor session)))
+        ;; the issuer was re-verified (identity resolved) before the token call
+        (let [urls (mapv :url @requests)]
+          (is (str/includes? (first urls) "plc.directory"))
+          (is (str/includes? (last urls) "/token")))
+        ;; the token request was a DPoP-signed refresh_token grant
+        (let [token-request (first (requests-to requests "/token"))
+              body (json/read-str (:body token-request))]
+          (is (= "refresh_token" (:grant_type body)))
+          (is (= "rt-1" (:refresh_token body)))
+          (is (= 3 (count (str/split (get-in token-request [:headers :dpop]) #"\.")))))
+        ;; the refreshed tokens were persisted with :iss and :expires-at
+        (let [stored (store/get (:session-store client) did)]
+          (is (= issuer (:iss stored)))
+          (is (= "at-2" (get-in stored [:tokens :access_token])))
+          (is (= "rt-2" (get-in stored [:tokens :refresh_token])))
+          (is (int? (get-in stored [:tokens :expires-at])))
+          (is (< (crypto/now) (get-in stored [:tokens :expires-at]))))))))
+
+(deftest refresh-single-flight-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        release (promise)
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/token" (fn [_]
+                                                      @release
+                                                      token-success-response)]))]
+    (with-redefs [http/handle-request handler]
+      (let [p1 (future @(oauth/refresh client did))
+            ;; wait for the first refresh to be in flight at the token endpoint
+            _ (loop [n 0]
+                (when (and (< n 100) (empty? (requests-to requests "/token")))
+                  (Thread/sleep 50)
+                  (recur (inc n))))
+            p2 (oauth/refresh client did)]
+        (deliver release true)
+        (let [s1 (deref p1 5000 ::timeout)
+              s2 (deref p2 5000 ::timeout)]
+          (is (= "at-2" (get-in s1 [:tokens :access_token])))
+          (is (= "at-2" (get-in s2 [:tokens :access_token])))
+          (is (= 1 (count (requests-to requests "/token")))))))))
+
+(deftest invalid-grant-adopts-foreign-refresh-test
+  (let [client (test-client)
+        seeded (seed-session! client)
+        {:keys [handler]} (fake-http/routed
+                           (conj resolution-routes
+                                 ["/token" (fake-http/json-response
+                                            400 {:error "invalid_grant"
+                                                 :error_description "refresh token replayed"})]))]
+    (with-redefs [http/handle-request handler]
+      (let [pending (oauth/refresh client did)]
+        ;; another process refreshed concurrently and stored different tokens
+        (store/set (:session-store client) did
+                   (update seeded :tokens assoc
+                           :access_token "at-foreign"
+                           :refresh_token "rt-foreign"))
+        (let [session (deref pending 5000 ::timeout)]
+          (is (nil? (:error session)))
+          (is (= "at-foreign" (get-in session [:tokens :access_token])))
+          ;; the foreign session was adopted, not deleted
+          (is (some? (store/get (:session-store client) did))))))))
+
+(deftest invalid-grant-deletes-session-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler]} (fake-http/routed
+                           (conj resolution-routes
+                                 ["/token" (fake-http/json-response
+                                            400 {:error "invalid_grant"
+                                                 :error_description "expired"})]))]
+    (with-redefs [http/handle-request handler]
+      (let [resp (deref (oauth/refresh client did) 5000 ::timeout)]
+        (is (= "TokenRefreshError" (:error resp)))
+        (is (= "expired" (:message resp)))
+        (is (nil? (store/get (:session-store client) did)))))))
+
+(deftest refresh-without-refresh-token-test
+  (let [client (test-client)
+        _ (seed-session! client {:tokens {:access_token "at-1"
+                                          :token_type "DPoP"
+                                          :sub did
+                                          :aud pds
+                                          :iss issuer}})
+        {:keys [handler requests]} (fake-http/routed resolution-routes)]
+    (with-redefs [http/handle-request handler]
+      (let [resp (deref (oauth/refresh client did) 5000 ::timeout)]
+        (is (= "TokenRefreshError" (:error resp)))
+        (is (nil? (store/get (:session-store client) did)))
+        (is (empty? @requests))))))
+
+(deftest refresh-network-error-keeps-session-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler]} (fake-http/routed
+                           (conj resolution-routes
+                                 ["/token" {:error "HTTPClientError"
+                                            :message "connection refused"}]))]
+    (with-redefs [http/handle-request handler]
+      (let [resp (deref (oauth/refresh client did) 5000 ::timeout)]
+        (is (= "HTTPClientError" (:error resp)))
+        ;; transient failure: the stored session is kept
+        (is (some? (store/get (:session-store client) did)))))))
+
+(deftest refresh-unknown-did-test
+  (let [client (test-client)]
+    (let [resp (deref (oauth/refresh client did) 1000 ::timeout)]
+      (is (= "SessionNotFound" (:error resp))))))
+
+(deftest restore-test
+  (let [client (test-client)
+        _ (seed-session! client)]
+    (let [session (deref (oauth/restore client did) 1000 ::timeout)]
+      (is (nil? (:error session)))
+      (is (= did (:did session)))
+      (is (= pds (:pds session)))
+      (is (map? (xrpc-client/auth-interceptor session))))))
+
+(deftest restore-unknown-did-never-hangs-test
+  (let [client (test-client)
+        resp (deref (oauth/restore client "did:plc:cccccccccccccccccccccccc") 1000 ::timeout)]
+    (is (= "SessionNotFound" (:error resp)))
+    (is (= "did:plc:cccccccccccccccccccccccc" (:did resp)))))
+
+(deftest restore-legacy-row-test
+  ;; legacy rows have no :iss and no :expires-at
+  (let [client (test-client)
+        dpop-key (dpop/generate-key)]
+    (store/set (:session-store client) did
+               {:did did
+                :did-doc did-doc
+                :dpop-key dpop-key
+                :tokens {:access_token "at-1"
+                         :refresh_token "rt-1"
+                         :token_type "DPoP"
+                         :sub did}})
+    (let [session (deref (oauth/restore client did) 1000 ::timeout)]
+      (is (nil? (:error session)))
+      (is (= "at-1" (get-in session [:tokens :access_token]))))))
+
+(deftest revoke-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/revoke" (fake-http/json-response {})]))]
+    (with-redefs [http/handle-request handler]
+      (let [resp (deref (oauth/revoke client did) 5000 ::timeout)]
+        (is (= {:did did :revoked true} resp))
+        ;; the access token was POSTed to the revocation endpoint
+        (let [revocation-request (first (requests-to requests "/revoke"))]
+          (is (some? revocation-request))
+          (is (= "at-1" (:token (json/read-str (:body revocation-request))))))
+        ;; the stored session is gone
+        (is (nil? (store/get (:session-store client) did)))
+        (is (= "SessionNotFound"
+               (:error (deref (oauth/restore client did) 1000 ::timeout))))))))
+
+(deftest revoke-server-error-still-deletes-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler]} (fake-http/routed
+                           (conj resolution-routes
+                                 ["/revoke" (fake-http/json-response 500 {:error "server_error"})]))]
+    (with-redefs [http/handle-request handler]
+      (let [resp (deref (oauth/revoke client did) 5000 ::timeout)]
+        (is (= {:did did :revoked true} resp))
+        (is (nil? (store/get (:session-store client) did)))))))
+
+(deftest revoke-without-revocation-endpoint-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed
+                                    [["/.well-known/oauth-authorization-server"
+                                      (fake-http/json-response (dissoc asmd :revocation_endpoint))]])]
+    (with-redefs [http/handle-request handler]
+      (let [resp (deref (oauth/revoke client did) 5000 ::timeout)]
+        (is (= {:did did :revoked true} resp))
+        (is (empty? (requests-to requests "/revoke")))
+        (is (nil? (store/get (:session-store client) did)))))))
+
+(deftest revoke-unknown-did-test
+  (let [client (test-client)
+        resp (deref (oauth/revoke client did) 1000 ::timeout)]
+    (is (= {:did did :revoked false} resp))))
+
+(deftest callback-expired-state-test
+  (let [client (test-client)
+        state "state-123"]
+    (store/set (:state-store client) state
+               {:iss issuer
+                :dpop-key (dpop/generate-key)
+                :identity {:did did :did-doc did-doc}
+                :verifier "verifier"
+                :created-at (- (crypto/now) 7200)})
+    (let [resp (deref (oauth/callback client {:state state :iss issuer :code "code"})
+                      1000 ::timeout)]
+      (is (= "StateExpired" (:error resp)))
+      (is (nil? (store/get (:state-store client) state))))))
+
+(deftest callback-unknown-state-test
+  (let [client (test-client)
+        resp (deref (oauth/callback client {:state "nope" :iss issuer :code "code"})
+                    1000 ::timeout)]
+    (is (= "Unknown state" (:error resp)))))
+
+;; -----------------------------------------------------------------------------
+;; Store
+;; -----------------------------------------------------------------------------
+
+(deftest memory-store-round-trip-test
+  (let [ms (store/memory-store)
+        session-data {:did did
+                      :did-doc did-doc
+                      :iss issuer
+                      :dpop-key (dpop/generate-key)
+                      :tokens {:access_token "at-1"
+                               :refresh_token "rt-1"
+                               :token_type "DPoP"
+                               :scope "atproto"
+                               :sub did
+                               :aud pds
+                               :expires-at 1760000000}}]
+    (store/set ms did session-data)
+    (is (= session-data (store/get ms did)))
+    (store/del ms did)
+    (is (nil? (store/get ms did)))))
+
+(deftest memory-store-evicts-expired-entries-test
+  (let [backing (atom {})
+        ms (store/memory-store backing)]
+    ;; an already-expired entry is not returned and is removed on read
+    (store/set ms "expired" {:expires-at (- (crypto/now) 10) :a 1})
+    (is (nil? (store/get ms "expired")))
+    (is (not (contains? @backing "expired")))
+    ;; a live entry with a future expiry is returned
+    (store/set ms "live" {:expires-at (+ (crypto/now) 100) :a 2})
+    (is (= 2 (:a (store/get ms "live"))))
+    ;; expired entries are swept on writes, even if never read
+    (store/set ms "abandoned" {:expires-at (- (crypto/now) 10) :a 3})
+    (store/set ms "other" {:b 4})
+    (is (not (contains? @backing "abandoned")))
+    ;; entries without :expires-at are kept forever
+    (is (= 4 (:b (store/get ms "other"))))))

--- a/test/atproto/oauth/client_test.clj
+++ b/test/atproto/oauth/client_test.clj
@@ -41,6 +41,19 @@
                                    :redirect_uris ["https://app.test/oauth/callback"]
                                    :scope "atproto"}}))
 
+(defn- tokens
+  "A stored token map with a future expiry, merged with `overrides`."
+  [& [overrides]]
+  (merge {:access_token "at-1"
+          :refresh_token "rt-1"
+          :token_type "DPoP"
+          :scope "atproto"
+          :sub did
+          :aud pds
+          :iss issuer
+          :expires-at (+ (crypto/now) 3600)}
+         overrides))
+
 (defn- seed-session!
   "Store a session for `did` and return the session data (with the dpop-key)."
   [client & [overrides]]
@@ -50,14 +63,7 @@
                              :did-doc did-doc
                              :iss issuer
                              :dpop-key dpop-key
-                             :tokens {:access_token "at-1"
-                                      :refresh_token "rt-1"
-                                      :token_type "DPoP"
-                                      :scope "atproto"
-                                      :sub did
-                                      :aud pds
-                                      :iss issuer
-                                      :expires-at 0}}
+                             :tokens (tokens)}
                             overrides)]
     (store/set (:session-store client) did session-data)
     session-data))
@@ -135,6 +141,49 @@
           (is (= "at-2" (get-in s2 [:tokens :access_token])))
           (is (= 1 (count (requests-to requests "/token")))))))))
 
+(deftest refresh-pins-sub-test
+  ;; the token response's sub is not adopted: the stored sub stays pinned to
+  ;; the session's DID (matching the reference, which ignores it on refresh)
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler]} (fake-http/routed
+                           (conj resolution-routes
+                                 ["/token" (fake-http/json-response
+                                            {:access_token "at-2"
+                                             :refresh_token "rt-2"
+                                             :token_type "DPoP"
+                                             :scope "atproto"
+                                             :sub "did:plc:zzzzzzzzzzzzzzzzzzzzzzzz"
+                                             :expires_in 300})]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/refresh client did) 5000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= did (get-in session [:tokens :sub])))
+        (is (= did (get-in (store/get (:session-store client) did) [:tokens :sub])))))))
+
+(deftest issuer-metadata-cache-ttl-test
+  ;; AS metadata is cached for issuer-metadata-ttl and re-fetched after that
+  (let [client (test-client)
+        {:keys [handler requests]} (fake-http/routed
+                                    [["/.well-known/oauth-authorization-server"
+                                      (fake-http/json-response asmd)]
+                                     ["/revoke" (fake-http/json-response {})]])
+        asmd-fetches #(count (requests-to requests "oauth-authorization-server"))]
+    (with-redefs [http/handle-request handler]
+      ;; first revoke fetches and caches the metadata, second hits the cache
+      (seed-session! client)
+      (is (= {:did did :revoked true} (deref (oauth/revoke client did) 5000 ::timeout)))
+      (is (= 1 (asmd-fetches)))
+      (seed-session! client)
+      (is (= {:did did :revoked true} (deref (oauth/revoke client did) 5000 ::timeout)))
+      (is (= 1 (asmd-fetches)))
+      ;; past the TTL the metadata is fetched again
+      (let [real-now crypto/now]
+        (with-redefs [crypto/now #(+ (real-now) (* 2 oauth/issuer-metadata-ttl))]
+          (seed-session! client)
+          (is (= {:did did :revoked true} (deref (oauth/revoke client did) 5000 ::timeout)))
+          (is (= 2 (asmd-fetches))))))))
+
 (deftest invalid-grant-adopts-foreign-refresh-test
   (let [client (test-client)
         seeded (seed-session! client)
@@ -168,6 +217,8 @@
       (let [resp (deref (oauth/refresh client did) 5000 ::timeout)]
         (is (= "TokenRefreshError" (:error resp)))
         (is (= "expired" (:message resp)))
+        ;; definitive failures are tagged so XRPC clients drop the session
+        (is (true? (:atproto.xrpc.client/session-expired? resp)))
         (is (nil? (store/get (:session-store client) did)))))))
 
 (deftest refresh-without-refresh-token-test
@@ -204,12 +255,51 @@
 
 (deftest restore-test
   (let [client (test-client)
-        _ (seed-session! client)]
-    (let [session (deref (oauth/restore client did) 1000 ::timeout)]
-      (is (nil? (:error session)))
-      (is (= did (:did session)))
-      (is (= pds (:pds session)))
-      (is (map? (xrpc-client/auth-interceptor session))))))
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed [])]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did) 1000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= did (:did session)))
+        (is (= pds (:pds session)))
+        (is (map? (xrpc-client/auth-interceptor session)))
+        ;; fresh tokens are returned as-is, without any network traffic
+        (is (empty? @requests))))))
+
+(deftest restore-refreshes-stale-tokens-test
+  ;; restore with the default :refresh :auto refreshes expired (or about to
+  ;; expire) tokens before returning the session
+  (let [client (test-client)
+        _ (seed-session! client {:tokens (tokens {:expires-at (crypto/now)})})
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/token" token-success-response]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did) 5000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= "at-2" (get-in session [:tokens :access_token])))
+        (is (= 1 (count (requests-to requests "/token"))))))))
+
+(deftest restore-refresh-false-returns-stale-tokens-test
+  (let [client (test-client)
+        _ (seed-session! client {:tokens (tokens {:expires-at 0})})
+        {:keys [handler requests]} (fake-http/routed [])]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did :refresh false) 1000 ::timeout)]
+        (is (nil? (:error session)))
+        (is (= "at-1" (get-in session [:tokens :access_token])))
+        (is (empty? @requests))))))
+
+(deftest restore-refresh-true-forces-refresh-test
+  (let [client (test-client)
+        _ (seed-session! client)
+        {:keys [handler requests]} (fake-http/routed
+                                    (conj resolution-routes
+                                          ["/token" token-success-response]))]
+    (with-redefs [http/handle-request handler]
+      (let [session (deref (oauth/restore client did :refresh true) 5000 ::timeout)]
+        (is (= "at-2" (get-in session [:tokens :access_token])))
+        (is (= 1 (count (requests-to requests "/token"))))))))
 
 (deftest restore-unknown-did-never-hangs-test
   (let [client (test-client)

--- a/test/atproto/test_support/http.cljc
+++ b/test/atproto/test_support/http.cljc
@@ -1,0 +1,62 @@
+(ns atproto.test-support.http
+  "Scripted/routed fakes for atproto.runtime.http/handle-request.
+
+  Use with-redefs to replace atproto.runtime.http/handle-request with the
+  :handler of one of these fakes; this exercises the real interceptor chains
+  (json, atproto-json, dpop, auth) against canned HTTP responses."
+  (:require [clojure.string :as str]
+            [atproto.runtime.json :as json]))
+
+(defn json-response
+  "A canned HTTP response with a JSON body."
+  ([body] (json-response 200 body))
+  ([status body] (json-response status nil body))
+  ([status headers body]
+   {:status status
+    :headers (merge {:content-type "application/json"} headers)
+    :body (json/write-str body)}))
+
+(defn scripted
+  "A fake handler that replays `responses` in order.
+
+  Returns {:handler f :requests requests-atom}: f is a drop-in replacement
+  for atproto.runtime.http/handle-request; every request received is appended
+  to the :requests atom. Each response may be a map or a
+  (fn [request] response). Requests beyond the script receive an
+  {:error \"NoScriptedResponse\"} map."
+  [responses]
+  (let [queue (atom (seq responses))
+        requests (atom [])]
+    {:requests requests
+     :handler (fn [request cb]
+                (swap! requests conj request)
+                (let [[prev _] (swap-vals! queue next)
+                      response (first prev)]
+                  (cond
+                    (nil? response) (cb {:error "NoScriptedResponse"
+                                         :message (str "No scripted response for "
+                                                       (some-> (:method request) name)
+                                                       " " (:url request))})
+                    (fn? response)  (cb (response request))
+                    :else           (cb response))))}))
+
+(defn routed
+  "A fake handler that dispatches on the request.
+
+  `routes` is an ordered seq of [matcher response] pairs; a matcher is a
+  substring of the request URL or a (fn [request] boolean); a response is a
+  map or a (fn [request] response). The first matching route wins; unmatched
+  requests receive an {:error \"NoRoute\"} map."
+  [routes]
+  (let [requests (atom [])]
+    {:requests requests
+     :handler (fn [{:keys [url] :as request} cb]
+                (swap! requests conj request)
+                (if-let [[_ response] (first (filter (fn [[matcher _]]
+                                                       (if (string? matcher)
+                                                         (str/includes? (or url "") matcher)
+                                                         (matcher request)))
+                                                     routes))]
+                  (cb (if (fn? response) (response request) response))
+                  (cb {:error "NoRoute"
+                       :message (str "No route for " url)})))}))

--- a/test/atproto/xrpc/client_test.cljc
+++ b/test/atproto/xrpc/client_test.cljc
@@ -1,0 +1,166 @@
+(ns atproto.xrpc.client-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.http :as http]
+            [atproto.runtime.json :as json]
+            [atproto.test-support.http :as fake-http]
+            [atproto.xrpc.client :as client]))
+
+(deftest invalid-token-response?-test
+  (are [expected response] (= expected (client/invalid-token-response? response))
+    true  {:status 400
+           :headers {:content-type "application/json"}
+           :body {:error "ExpiredToken"}}
+    ;; content-type prefix match (charset suffix)
+    true  {:status 400
+           :headers {:content-type "application/json; charset=utf-8"}
+           :body {:error "ExpiredToken"}}
+    ;; 401 with no WWW-Authenticate header (bearer-auth convention)
+    true  {:status 401 :headers {}}
+    ;; RFC 6750/9449 invalid_token challenges
+    true  {:status 401
+           :headers {:www-authenticate "DPoP error=\"invalid_token\", error_description=\"x\""}}
+    true  {:status 401
+           :headers {:www-authenticate "Bearer error=\"invalid_token\""}}
+    ;; the DPoP interceptor owns the nonce dance
+    false {:status 401
+           :headers {:www-authenticate "DPoP error=\"use_dpop_nonce\""}}
+    false {:status 200
+           :headers {:content-type "application/json"}
+           :body {:error "ExpiredToken"}}
+    false {:status 400
+           :headers {:content-type "application/json"}
+           :body {:error "InvalidRequest"}}
+    false {:status 400
+           :headers {:content-type "text/plain"}
+           :body "ExpiredToken"}
+    false {:error "HTTPClientError" :status 401 :headers {}}))
+
+(defn- stub-session
+  "A Session implemented via metadata: authenticates with `Bearer <token>`
+  and delegates refresh-token to refresh-fn."
+  [token refresh-fn]
+  (with-meta
+    {:token token :pds "https://pds.test"}
+    {`client/auth-interceptor
+     (fn [session]
+       {::i/name ::stub-auth
+        ::i/enter #(assoc-in % [::i/request :headers :authorization]
+                             (str "Bearer " (:token session)))})
+     `client/refresh-token
+     (fn [session cb] (refresh-fn session cb))}))
+
+(def ^:private expired-response
+  (fake-http/json-response 400 {:error "ExpiredToken"}))
+
+(defn- bearer
+  [request]
+  (get-in request [:headers :authorization]))
+
+#?(:clj
+   (deftest refresh-and-retry-test
+     (let [refresh-calls (atom 0)
+           session (stub-session "old"
+                                 (fn [_ cb]
+                                   (swap! refresh-calls inc)
+                                   (cb (stub-session "new" (fn [_ cb] (cb {:error "TokenRefreshError"}))))))
+           {:keys [handler requests]} (fake-http/routed
+                                       [[#(= "Bearer old" (bearer %)) expired-response]
+                                        [#(= "Bearer new" (bearer %)) (fake-http/json-response {:result "ok"})]])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc"
+                                                   :body {:hello "world"}})
+                           1000 ::timeout)]
+           (is (= {:result "ok"} resp))
+           (is (= 1 @refresh-calls))
+           (is (= 2 (count @requests)))
+           (let [[r1 r2] @requests]
+             (is (= "Bearer old" (bearer r1)))
+             ;; the retried request carried the NEW token...
+             (is (= "Bearer new" (bearer r2)))
+             ;; ...and a singly-encoded JSON body, byte-identical to the original
+             (is (= {:hello "world"} (json/read-str (:body r1))))
+             (is (= (:body r1) (:body r2)))))
+         ;; the client's session atom holds the new session
+         (is (= "new" (:token @(:session xrpc))))))))
+
+#?(:clj
+   (deftest refresh-failure-delivers-full-error-map-test
+     (let [session (stub-session "old"
+                                 (fn [_ cb] (cb {:error "TokenRefreshError" :message "x"})))
+           {:keys [handler]} (fake-http/scripted [expired-response])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           (is (= {:error "TokenRefreshError" :message "x"} resp)))))))
+
+#?(:clj
+   (deftest refresh-token-throwing-delivers-error-test
+     (let [session (stub-session "old"
+                                 (fn [_ _] (throw (ex-info "boom" {}))))
+           {:keys [handler]} (fake-http/scripted [expired-response])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           (is (= "TokenRefreshError" (:error resp))))))))
+
+#?(:clj
+   (deftest retry-at-most-once-test
+     (let [refresh-calls (atom 0)
+           make-session (fn make-session [token]
+                          (stub-session token
+                                        (fn [_ cb]
+                                          (swap! refresh-calls inc)
+                                          (cb (make-session "refreshed")))))
+           {:keys [handler requests]} (fake-http/scripted (repeat 5 expired-response))
+           xrpc (client/init {:session (make-session "initial")})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           ;; the second invalid-token response is returned as-is
+           (is (= "ExpiredToken" (:error resp)))
+           (is (= 1 @refresh-calls))
+           (is (= 2 (count @requests))))))))
+
+#?(:clj
+   (deftest refresh-session-not-recursed-test
+     ;; a session marked :refresh? never triggers another refresh
+     (let [refresh-calls (atom 0)
+           session (assoc (stub-session "r" (fn [_ cb]
+                                              (swap! refresh-calls inc)
+                                              (cb {:error "TokenRefreshError"})))
+                          :refresh? true)
+           {:keys [handler]} (fake-http/scripted [expired-response])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           (is (= "ExpiredToken" (:error resp)))
+           (is (= 0 @refresh-calls)))))))
+
+#?(:clj
+   (deftest single-flight-refresh-test
+     (let [refresh-calls (atom 0)
+           release (promise)
+           session (stub-session "old"
+                                 (fn [_ cb]
+                                   (swap! refresh-calls inc)
+                                   (future
+                                     @release
+                                     (cb (stub-session "new" (fn [_ cb] (cb {:error "TokenRefreshError"})))))))
+           {:keys [handler]} (fake-http/routed
+                              [[#(= "Bearer old" (bearer %)) expired-response]
+                               [#(= "Bearer new" (bearer %)) (fake-http/json-response {:ok true})]])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         ;; all 32 requests hit the expired response and queue on one refresh
+         (let [results (doall (repeatedly 32 #(client/procedure xrpc {:nsid "com.example.proc"
+                                                                      :body {:n 1}})))]
+           (deliver release true)
+           (doseq [result results]
+             (is (= {:ok true} (deref result 2000 ::timeout))))
+           (is (= 1 @refresh-calls)))))))

--- a/test/atproto/xrpc/client_test.cljc
+++ b/test/atproto/xrpc/client_test.cljc
@@ -95,7 +95,30 @@
        (with-redefs [http/handle-request handler]
          (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
                            1000 ::timeout)]
-           (is (= {:error "TokenRefreshError" :message "x"} resp)))))))
+           (is (= {:error "TokenRefreshError" :message "x"} resp))
+           ;; a transient refresh failure keeps the session in place
+           (is (= "old" (:token @(:session xrpc)))))))))
+
+#?(:clj
+   (deftest definitive-refresh-failure-drops-session-test
+     ;; an error tagged ::client/session-expired? drops the session: the
+     ;; error is delivered and subsequent requests go out unauthenticated
+     (let [session (stub-session "old"
+                                 (fn [_ cb] (cb {:error "TokenRefreshError"
+                                                 ::client/session-expired? true})))
+           {:keys [handler requests]} (fake-http/scripted
+                                       [expired-response
+                                        (fake-http/json-response {:anon true})])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           (is (= "TokenRefreshError" (:error resp)))
+           (is (nil? @(:session xrpc)))
+           (let [resp2 (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                              1000 ::timeout)]
+             (is (= {:anon true} resp2))
+             (is (nil? (bearer (second @requests))))))))))
 
 #?(:clj
    (deftest refresh-token-throwing-delivers-error-test


### PR DESCRIPTION
Brings the WS-01 auth & session lifecycle work (including the merged #12) into `redesign`.

## XRPC client (`atproto.xrpc.client`)
- `invalid-token-response?` replaces `expired-token-error?` (kept as a deprecated alias): 400 + JSON `ExpiredToken`, 401 without a `WWW-Authenticate` challenge, or 401 with a `Bearer`/`DPoP` `invalid_token` challenge (RFC 6750/9449). `use_dpop_nonce` 401s are left to the DPoP interceptor.
- `delegate-auth-interceptor` rewritten: replays the pristine request once after a refresh (fixes JSON double-encoding), single-flights concurrent refreshes, propagates the full `{:error ...}` map on refresh failure, and never hangs.
- Definitive refresh failures (tagged `::session-expired?`) drop the dead session from the client; transient failures keep it. The session atom is watchable for logout-on-expiry hooks.
- Body-less procedures (`refreshSession`, `deleteSession`) no longer throw.

## Credentials sessions (`atproto.credentials`)
- `refreshSession` flow fixed end-to-end: correct client init, refreshed JWTs no longer dropped, `:did`/`:pds`/`:handle` preserved when the response omits them, DID changes rejected as `InvalidDID`.
- HTTP 401, `ExpiredToken`, `InvalidToken`, and `InvalidDID` refresh failures kill the session (matching the reference's session-termination semantics); network errors keep it.
- New `logout` via `com.atproto.server.deleteSession` with the refresh JWT.

## OAuth client (`atproto.oauth.client`)
- Implements the DPoP-bound `refresh_token` grant (replaces the `'todo` stub): issuer re-verified before each refresh, tokens persisted with `:iss`/`:expires-at`, `:sub` pinned to the session DID, single-flighted per DID, with `invalid_grant` race recovery (adopt a concurrent foreign refresh or delete the session).
- `restore` refreshes stale tokens by default (`:refresh :auto`/`true`/`false`), resolves to `{:error "SessionNotFound"}` instead of hanging, and tolerates legacy stored sessions.
- New `revoke`: best-effort AS revocation, then unconditional local deletion; `callback` revokes any pre-existing session for the same DID first.
- AS metadata fetched on demand by `:iss` and cached for 60s; `callback` no longer depends on the in-memory cache surviving between authorize and callback.
- Pending-authorization state entries expire after 1h (`StateExpired`).

## Store & example
- `memory-store` lazily evicts entries that declare a top-level `:expires-at`.
- Statusphere logout revokes the OAuth session before clearing the ring session.

## Tests
Scripted/routed fake HTTP support plus suites for the XRPC auth-retry core, credentials lifecycle, OAuth refresh/revoke/restore/state-TTL, and the memory store. Behavior verified against the `bluesky-social/atproto` reference implementation (`packages/api`, `packages/oauth/oauth-client`). Full suite: 47 tests, 896 assertions, 0 failures.

https://claude.ai/code/session_013QJ83JMiK3hDwUJphePX5W

---
_Generated by [Claude Code](https://claude.ai/code/session_013QJ83JMiK3hDwUJphePX5W)_