### PR TITLE
WS-03: Cryptography parity (atproto.crypto, runtime crypto fixes, JWS/JWT verify)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,7 @@
         org.slf4j/slf4j-simple {:mvn/version "2.0.16"}
         com.nimbusds/nimbus-jose-jwt {:mvn/version "10.0.2"}
         com.google.crypto.tink/tink {:mvn/version "1.7.0"}
+        org.bouncycastle/bcprov-jdk18on {:mvn/version "1.80"}
         mvxcvi/multiformats {:mvn/version "1.0.125"}}
  :aliases {:dev  {:extra-paths ["test" "dev" "examples"]
                   :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}

--- a/src/atproto/crypto.cljc
+++ b/src/atproto/crypto.cljc
@@ -1,0 +1,512 @@
+(ns atproto.crypto
+  "ECDSA keypairs, signatures, and did:key encoding for atproto.
+
+  Two curves are supported, identified by their JWT `alg` string:
+    \"ES256\"  — NIST P-256 / secp256r1 / prime256v1
+    \"ES256K\" — secp256k1 / K-256
+
+  Signatures are 64-byte compact R||S over the SHA-256 of the message,
+  with low-S normalization. Verification rejects high-S and DER-encoded
+  signatures unless :allow-malleable? is set.
+
+  Key operations (generate, import-private-key, sign, verify,
+  verify-did-sig) follow the SDK async convention: they take a trailing
+  options map with :callback/:promise/:channel adapters so that a future
+  ClojureScript backend can use the Promise-based WebCrypto API. On the
+  JVM they compute synchronously and adapt. Parsing/encoding helpers are
+  synchronous. Errors are {:error \"Name\" :message ...} maps, never
+  thrown; verify yields plain false for well-formed-but-invalid
+  signatures.
+
+  See https://atproto.com/specs/cryptography"
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [multiformats.base :as mb]
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.crypto :as runtime.crypto])
+  #?(:clj (:import [java.math BigInteger]
+                   [java.security SecureRandom]
+                   [java.util Arrays]
+                   [org.bouncycastle.asn1 ASN1Integer ASN1Primitive ASN1Sequence]
+                   [org.bouncycastle.crypto AsymmetricCipherKeyPair]
+                   [org.bouncycastle.crypto.digests SHA256Digest]
+                   [org.bouncycastle.crypto.ec CustomNamedCurves]
+                   [org.bouncycastle.crypto.generators ECKeyPairGenerator]
+                   [org.bouncycastle.crypto.params ECDomainParameters
+                    ECKeyGenerationParameters ECPrivateKeyParameters
+                    ECPublicKeyParameters]
+                   [org.bouncycastle.crypto.signers ECDSASigner HMacDSAKCalculator]
+                   [org.bouncycastle.math.ec ECPoint])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- async-opts
+  "The async-adapter keys of an options map (see i/platform-async).
+  Other keys must be stripped before requesting the platform default."
+  [opts]
+  (select-keys opts [:channel :callback :promise]))
+
+(def p256-jwt-alg "ES256")
+(def k256-jwt-alg "ES256K")
+
+(def did-key-prefix "did:key:")
+
+(s/def ::alg #{"ES256" "ES256K"})
+(s/def ::did-key (s/and string? #(str/starts-with? % "did:key:z")))
+
+#?(:clj (s/def ::compressed-pubkey (s/and bytes/bytes? #(= 33 (alength ^bytes %)))))
+#?(:clj (s/def ::uncompressed-pubkey (s/and bytes/bytes? #(= 65 (alength ^bytes %)))))
+#?(:clj (s/def ::compact-sig (s/and bytes/bytes? #(= 64 (alength ^bytes %)))))
+
+;; -----------------------------------------------------------------------------
+;; Curve parameters & byte helpers (JVM, BouncyCastle lightweight API)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (def ^:private domains
+     "JWT alg string -> BouncyCastle ECDomainParameters."
+     (into {}
+           (map (fn [[alg curve-name]]
+                  (let [x9 (CustomNamedCurves/getByName curve-name)]
+                    [alg (ECDomainParameters. (.getCurve x9) (.getG x9) (.getN x9) (.getH x9))])))
+           {"ES256" "secp256r1"
+            "ES256K" "secp256k1"})))
+
+;; Multicodec varint prefixes (P-256 = 0x1200, secp256k1 = 0xe7), hardcoded
+;; as in the reference implementation's const.ts.
+#?(:clj
+   (def ^:private did-prefixes
+     {"ES256" (byte-array [(unchecked-byte 0x80) 0x24])
+      "ES256K" (byte-array [(unchecked-byte 0xe7) 0x01])}))
+
+#?(:clj
+   (defn- prefix-match?
+     [^bytes prefix ^bytes b]
+     (and (<= (alength prefix) (alength b))
+          (Arrays/equals prefix (Arrays/copyOfRange b 0 (alength prefix))))))
+
+#?(:clj
+   (defn- concat-bytes
+     ^bytes [^bytes a ^bytes b]
+     (let [out (byte-array (+ (alength a) (alength b)))]
+       (System/arraycopy a 0 out 0 (alength a))
+       (System/arraycopy b 0 out (alength a) (alength b))
+       out)))
+
+#?(:clj
+   (defn- bigint->32-bytes
+     "Fixed-width 32-byte big-endian encoding of a non-negative BigInteger
+     (strips BigInteger/toByteArray's sign byte, left-pads short values)."
+     ^bytes [^BigInteger v]
+     (let [b (.toByteArray v)
+           len (alength b)
+           out (byte-array 32)]
+       (if (<= len 32)
+         (System/arraycopy b 0 out (- 32 len) len)
+         (System/arraycopy b (- len 32) out 0 32))
+       out)))
+
+#?(:clj
+   (defn- decode-point
+     "Decode and validate a compressed or uncompressed public key on the
+     given curve. Returns an ECPoint or nil if invalid."
+     ^ECPoint [^ECDomainParameters domain ^bytes pubkey-bytes]
+     (try
+       (.decodePoint (.getCurve domain) pubkey-bytes)
+       (catch Exception _ nil))))
+
+;; -----------------------------------------------------------------------------
+;; Public key encoding & did:key (FROZEN CONTRACT)
+;; -----------------------------------------------------------------------------
+
+(defn compress-pubkey
+  "33-byte compressed form of a public key (accepts 33 or 65 byte input).
+  Returns {:error \"InvalidPublicKey\"} if not a valid curve point."
+  [alg pubkey-bytes]
+  #?(:clj
+     (if-let [^ECDomainParameters domain (domains alg)]
+       (if-let [point (decode-point domain pubkey-bytes)]
+         (.getEncoded point true)
+         {:error "InvalidPublicKey"
+          :message "Not a valid public key for this curve."})
+       {:error "UnsupportedAlgorithm"
+        :message (str "Unsupported algorithm: " (pr-str alg))})))
+
+(defn decompress-pubkey
+  "65-byte uncompressed form of a 33-byte compressed public key.
+  Returns {:error \"InvalidPublicKey\"} on bad length or invalid point."
+  [alg pubkey-bytes]
+  #?(:clj
+     (if-let [^ECDomainParameters domain (domains alg)]
+       (if (not= 33 (alength ^bytes pubkey-bytes))
+         {:error "InvalidPublicKey"
+          :message "Expected a 33-byte compressed public key."}
+         (if-let [point (decode-point domain pubkey-bytes)]
+           (.getEncoded point false)
+           {:error "InvalidPublicKey"
+            :message "Not a valid public key for this curve."}))
+       {:error "UnsupportedAlgorithm"
+        :message (str "Unsupported algorithm: " (pr-str alg))})))
+
+(defn format-multikey
+  "Multikey string (\"z...\") for the public key — did:key without the
+  \"did:key:\" prefix: base58btc of multicodec-prefix ++ compressed-pubkey.
+  Returns {:error \"UnsupportedAlgorithm\"|\"InvalidPublicKey\" ...} on bad input."
+  [alg pubkey-bytes]
+  #?(:clj
+     (if-let [^bytes prefix (did-prefixes alg)]
+       (let [compressed (compress-pubkey alg pubkey-bytes)]
+         (if (map? compressed)
+           compressed
+           (mb/format :base58btc (concat-bytes prefix compressed))))
+       {:error "UnsupportedAlgorithm"
+        :message (str "Unsupported algorithm: " (pr-str alg))})))
+
+(defn parse-multikey
+  "Parse a multikey string (\"z...\").
+  Returns {:alg \"ES256\"|\"ES256K\" :bytes uncompressed-65-byte-pubkey}
+  or {:error \"InvalidDidKey\"|\"UnsupportedKeyType\"|\"InvalidPublicKey\" ...}."
+  [multikey]
+  #?(:clj
+     (if-not (and (string? multikey) (str/starts-with? multikey "z"))
+       {:error "InvalidDidKey"
+        :message "Multikey must be a base58btc ('z'-prefixed) string."}
+       (let [prefixed (try (mb/parse multikey) (catch Exception _ nil))]
+         (if (nil? prefixed)
+           {:error "InvalidDidKey"
+            :message "Invalid base58btc encoding."}
+           (if-let [alg (some (fn [[alg ^bytes prefix]]
+                                (when (prefix-match? prefix prefixed) alg))
+                              did-prefixes)]
+             (let [^bytes prefix (did-prefixes alg)
+                   key-bytes (Arrays/copyOfRange ^bytes prefixed
+                                                 (alength prefix)
+                                                 (alength ^bytes prefixed))
+                   uncompressed (decompress-pubkey alg key-bytes)]
+               (if (map? uncompressed)
+                 uncompressed
+                 {:alg alg :bytes uncompressed}))
+             {:error "UnsupportedKeyType"
+              :message "Unsupported did:key multicodec prefix."}))))))
+
+(defn pubkey->did-key
+  "did:key string for the public key (compressed or uncompressed input):
+  \"did:key:z\" + base58btc(multicodec-prefix ++ compressed-pubkey).
+  Returns {:error \"UnsupportedAlgorithm\"|\"InvalidPublicKey\" ...} on bad input."
+  [alg pubkey-bytes]
+  (let [multikey (format-multikey alg pubkey-bytes)]
+    (if (map? multikey)
+      multikey
+      (str did-key-prefix multikey))))
+
+(defn did-key->pubkey
+  "Parse a did:key string.
+  Returns {:alg \"ES256\"|\"ES256K\" :bytes uncompressed-65-byte-pubkey}
+  or {:error \"InvalidDidKey\"|\"UnsupportedKeyType\" :message ...}."
+  [did]
+  (if-not (and (string? did) (str/starts-with? did did-key-prefix))
+    {:error "InvalidDidKey"
+     :message (str "did:key must start with " (pr-str did-key-prefix) ".")}
+    (parse-multikey (subs did (count did-key-prefix)))))
+
+(defn multibase->bytes
+  "Decode a multibase-prefixed string to bytes (multiformats.base/parse).
+  Returns {:error \"InvalidMultibase\" ...} on unknown prefix or bad encoding."
+  [s]
+  (try
+    (mb/parse s)
+    (catch #?(:clj Exception :cljs :default) e
+      {:error "InvalidMultibase" :message (ex-message e)})))
+
+(defn bytes->multibase
+  "Encode bytes as a multibase-prefixed string for the given base keyword,
+  e.g. (bytes->multibase :base58btc b) => \"z...\" (multiformats.base/format)."
+  [base-key b]
+  (mb/format base-key b))
+
+;; -----------------------------------------------------------------------------
+;; ECDSA signing & verification internals (JVM)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (defn- ecdsa-sign
+     "64-byte compact low-S signature of (sha256 msg) with deterministic
+     nonces (RFC 6979, parity with noble)."
+     ^bytes [alg ^BigInteger d ^bytes msg]
+     (let [^ECDomainParameters domain (domains alg)
+           n (.getN domain)
+           signer (ECDSASigner. (HMacDSAKCalculator. (SHA256Digest.)))]
+       (.init signer true (ECPrivateKeyParameters. d domain))
+       (let [^"[Ljava.math.BigInteger;" rs (.generateSignature signer (runtime.crypto/sha256 msg))
+             r (aget rs 0)
+             ^BigInteger s (aget rs 1)
+             s (if (pos? (.compareTo s (.shiftRight n 1)))
+                 (.subtract n s)
+                 s)]
+         (concat-bytes (bigint->32-bytes r) (bigint->32-bytes s))))))
+
+#?(:clj
+   (defn- parse-compact-sig
+     "[r s] from a 64-byte compact signature, or nil."
+     [^bytes sig]
+     (when (and sig (= 64 (alength sig)))
+       [(BigInteger. 1 (Arrays/copyOfRange sig 0 32))
+        (BigInteger. 1 (Arrays/copyOfRange sig 32 64))])))
+
+#?(:clj
+   (defn- parse-der-sig
+     "[r s] from a DER-encoded ECDSA signature, or nil."
+     [^bytes sig]
+     (try
+       (let [obj (ASN1Primitive/fromByteArray sig)]
+         (when (instance? ASN1Sequence obj)
+           (let [^ASN1Sequence sq obj]
+             (when (= 2 (.size sq))
+               [(.getValue (ASN1Integer/getInstance (.getObjectAt sq 0)))
+                (.getValue (ASN1Integer/getInstance (.getObjectAt sq 1)))]))))
+       (catch Exception _ nil))))
+
+#?(:clj
+   (defn- parse-sig
+     "[r s] from signature bytes per the atproto malleability rules, or nil.
+
+     Strict (default): exactly 64-byte compact and low-S.
+     Malleable: DER or compact, high-S accepted (noble parity: DER is
+     tried first, then compact)."
+     [^ECDomainParameters domain ^bytes sig allow-malleable?]
+     (if allow-malleable?
+       (or (parse-der-sig sig)
+           (parse-compact-sig sig))
+       (when-let [[_ ^BigInteger s :as rs] (parse-compact-sig sig)]
+         (when-not (pos? (.compareTo s (.shiftRight (.getN domain) 1)))
+           rs)))))
+
+#?(:clj
+   (defn- verify-sync
+     "true/false, or {:error ...} for unsupported alg / invalid pubkey."
+     [pubkey-bytes sig-bytes msg-bytes alg allow-malleable?]
+     (if-let [^ECDomainParameters domain (domains alg)]
+       (if-let [point (decode-point domain pubkey-bytes)]
+         (if-let [[r s] (parse-sig domain sig-bytes allow-malleable?)]
+           (let [signer (ECDSASigner.)]
+             (.init signer false (ECPublicKeyParameters. point domain))
+             (.verifySignature signer (runtime.crypto/sha256 msg-bytes)
+                               ^BigInteger r ^BigInteger s))
+           false)
+         {:error "InvalidPublicKey"
+          :message "Not a valid public key for this curve."})
+       {:error "UnsupportedAlgorithm"
+        :message (str "Unsupported algorithm: " (pr-str alg))})))
+
+;; -----------------------------------------------------------------------------
+;; Keypairs
+;; -----------------------------------------------------------------------------
+
+(defprotocol Keypair
+  (alg [kp]
+    "The JWT algorithm string for this keypair: \"ES256\" or \"ES256K\".")
+  (public-key [kp]
+    "Compressed public key bytes (33 bytes, 0x02/0x03-prefixed).")
+  (did [kp]
+    "The did:key string for this keypair's public key.")
+  (-sign [kp msg-bytes]
+    "Synchronous signing primitive; use the async `sign` fn instead.")
+  (export [kp]
+    "Raw 32-byte private key, or {:error \"PrivateKeyNotExportable\"}
+    if the keypair was not created with :exportable? true."))
+
+#?(:clj
+   (deftype ECKeypair [alg-str ^BigInteger d ^bytes pubkey did-str exportable?]
+     Keypair
+     (alg [_] alg-str)
+     (public-key [_] pubkey)
+     (did [_] did-str)
+     (-sign [_ msg-bytes] (ecdsa-sign alg-str d msg-bytes))
+     (export [_]
+       (if exportable?
+         (bigint->32-bytes d)
+         {:error "PrivateKeyNotExportable"
+          :message "Keypair was not created with :exportable? true."}))))
+
+#?(:clj
+   (defn- make-keypair
+     [alg ^BigInteger d exportable?]
+     (let [^ECDomainParameters domain (domains alg)
+           pubkey (.getEncoded (.multiply (.getG domain) d) true)]
+       (->ECKeypair alg d pubkey (pubkey->did-key alg pubkey) (boolean exportable?)))))
+
+#?(:clj
+   (defn- generate-sync
+     [alg exportable?]
+     (if-let [^ECDomainParameters domain (domains alg)]
+       (let [gen (ECKeyPairGenerator.)]
+         (.init gen (ECKeyGenerationParameters. domain (SecureRandom.)))
+         (let [^AsymmetricCipherKeyPair kp (.generateKeyPair gen)
+               d (.getD ^ECPrivateKeyParameters (.getPrivate kp))]
+           (make-keypair alg d exportable?)))
+       {:error "UnsupportedAlgorithm"
+        :message (str "Unsupported algorithm: " (pr-str alg))})))
+
+#?(:clj
+   (defn- import-private-key-sync
+     [alg priv exportable?]
+     (if-let [^ECDomainParameters domain (domains alg)]
+       (let [b (cond
+                 (bytes/bytes? priv) priv
+                 (string? priv) (runtime.crypto/hex-decode priv))]
+         (cond
+           (nil? b)
+           {:error "InvalidPrivateKey"
+            :message "Private key must be a 32-byte array or hex string."}
+
+           (not= 32 (alength ^bytes b))
+           {:error "InvalidPrivateKey"
+            :message "Private key must be exactly 32 bytes."}
+
+           :else
+           (let [d (BigInteger. 1 ^bytes b)]
+             (if (or (zero? (.signum d))
+                     (<= 0 (.compareTo d (.getN domain))))
+               {:error "InvalidPrivateKey"
+                :message "Private key scalar out of range for the curve."}
+               (make-keypair alg d exportable?)))))
+       {:error "UnsupportedAlgorithm"
+        :message (str "Unsupported algorithm: " (pr-str alg))})))
+
+(defn generate
+  "Generate a new keypair on the given curve (\"ES256\" or \"ES256K\").
+
+  opts:
+    :exportable?  allow `export` of the private key (default false)
+
+  Async; yields a Keypair or {:error \"UnsupportedAlgorithm\" :message ...}."
+  [alg & {:keys [exportable?] :as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (cb #?(:clj (generate-sync alg exportable?)
+           :cljs {:error "NotImplemented"
+                  :message "atproto.crypto is not yet implemented on ClojureScript."}))
+    val))
+
+(defn import-private-key
+  "Build a keypair from a raw 32-byte private scalar.
+  `priv` may be a byte array or a hex string (TS parity).
+
+  opts:
+    :exportable?  allow `export` of the private key (default false)
+
+  Async; yields a Keypair or {:error \"InvalidPrivateKey\" :message ...}."
+  [alg priv & {:keys [exportable?] :as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (cb #?(:clj (import-private-key-sync alg priv exportable?)
+           :cljs {:error "NotImplemented"
+                  :message "atproto.crypto is not yet implemented on ClojureScript."}))
+    val))
+
+(def ^:private alg->crv {"ES256" "P-256", "ES256K" "secp256k1"})
+(def ^:private crv->alg {"P-256" "ES256", "secp256k1" "ES256K"})
+
+(defn keypair->jwk
+  "Private EC JWK map for the keypair:
+  {:kty \"EC\" :crv \"P-256\"|\"secp256k1\" :x .. :y .. :d ..}
+  (base64url-encoded coordinates, RFC 7518 §6.2 / RFC 8812).
+  Returns {:error \"PrivateKeyNotExportable\"} unless exportable."
+  [kp]
+  #?(:clj
+     (let [priv (export kp)]
+       (if (map? priv)
+         priv
+         (let [^bytes uncompressed (decompress-pubkey (alg kp) (public-key kp))]
+           {:kty "EC"
+            :crv (alg->crv (alg kp))
+            :x (runtime.crypto/base64url-encode (Arrays/copyOfRange uncompressed 1 33))
+            :y (runtime.crypto/base64url-encode (Arrays/copyOfRange uncompressed 33 65))
+            :d (runtime.crypto/base64url-encode ^bytes priv)})))))
+
+(defn jwk->keypair
+  "Keypair from a private EC JWK map (inverse of keypair->jwk).
+  Returns {:error \"InvalidJwk\" :message ...} on bad input."
+  [jwk & {:keys [exportable?]}]
+  #?(:clj
+     (let [{:keys [kty crv x y d]} jwk
+           alg (crv->alg crv)]
+       (if (or (not= "EC" kty) (nil? alg))
+         {:error "InvalidJwk"
+          :message "Expected an EC JWK with :crv \"P-256\" or \"secp256k1\"."}
+         (let [db (when (string? d) (runtime.crypto/base64url-decode d))]
+           (if (or (nil? db) (not= 32 (alength ^bytes db)))
+             {:error "InvalidJwk"
+              :message "Missing or invalid private key component (:d)."}
+             (let [kp (import-private-key-sync alg db exportable?)]
+               (if (map? kp)
+                 {:error "InvalidJwk" :message (:message kp)}
+                 (let [^bytes uncompressed (decompress-pubkey alg (public-key kp))]
+                   (if (and (or (nil? x)
+                                (bytes/eq? (Arrays/copyOfRange uncompressed 1 33)
+                                           (runtime.crypto/base64url-decode x)))
+                            (or (nil? y)
+                                (bytes/eq? (Arrays/copyOfRange uncompressed 33 65)
+                                           (runtime.crypto/base64url-decode y))))
+                     kp
+                     {:error "InvalidJwk"
+                      :message "JWK public key does not match its private key."}))))))))))
+
+;; -----------------------------------------------------------------------------
+;; Signing & verification (FROZEN CONTRACT)
+;; -----------------------------------------------------------------------------
+
+(defn sign
+  "ECDSA signature of (sha256 msg-bytes) with the keypair.
+  Async; yields the 64-byte compact low-S R||S signature bytes."
+  [keypair msg-bytes & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (cb (-sign keypair msg-bytes))
+    val))
+
+(defn verify
+  "Verify an ECDSA signature over (sha256 msg-bytes).
+
+  pubkey-bytes  compressed (33) or uncompressed (65) public key
+  sig-bytes     signature bytes
+  opts          {:alg \"ES256\"|\"ES256K\"   ;; required
+                 :allow-malleable? false}    ;; default false
+
+  Default (strict, atproto rules): sig must be exactly 64 bytes compact
+  and low-S. With :allow-malleable? true: DER or compact accepted, high-S
+  accepted (TS parity: noble `format: undefined, lowS: false`).
+
+  Async; yields true/false. Malformed signatures yield false; an
+  unsupported :alg or an invalid public key yields {:error ...}
+  (programmer error, distinct from signature invalidity)."
+  [pubkey-bytes sig-bytes msg-bytes & {:keys [alg allow-malleable?] :as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (cb #?(:clj (verify-sync pubkey-bytes sig-bytes msg-bytes alg allow-malleable?)
+           :cljs {:error "NotImplemented"
+                  :message "atproto.crypto is not yet implemented on ClojureScript."}))
+    val))
+
+(defn verify-did-sig
+  "Verify a signature against the public key embedded in a did:key string,
+  dispatching on its multicodec prefix (TS verifySignature).
+
+  opts: {:alg ..               ;; optional assertion; error if it mismatches the did
+         :allow-malleable? false}
+
+  Async; yields true/false, or {:error ...} for a malformed/unsupported did:key."
+  [did-key sig-bytes msg-bytes & {:keys [alg allow-malleable?] :as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (cb (let [parsed (did-key->pubkey did-key)]
+          (cond
+            (:error parsed)
+            parsed
+
+            (and alg (not= alg (:alg parsed)))
+            {:error "AlgorithmMismatch"
+             :message (str "Expected key alg " alg ", got " (:alg parsed) ".")}
+
+            :else
+            #?(:clj (verify-sync (:bytes parsed) sig-bytes msg-bytes
+                                 (:alg parsed) allow-malleable?)
+               :cljs {:error "NotImplemented"
+                      :message "atproto.crypto is not yet implemented on ClojureScript."}))))
+    val))

--- a/src/atproto/runtime/crypto.cljc
+++ b/src/atproto/runtime/crypto.cljc
@@ -1,7 +1,7 @@
 (ns atproto.runtime.crypto
   "Cross-platform cryptographic functions for atproto."
   (:require [clojure.string :as str])
-  #?(:clj (:import [java.util Base64]
+  #?(:clj (:import [java.util Base64 HexFormat]
                    [com.nimbusds.jose.util Base64URL]
                    [java.security SecureRandom MessageDigest]
                    [java.nio.charset StandardCharsets])))
@@ -21,14 +21,36 @@
             seed)))
 
 (defn sha256
-  "sha256 of the bytes"
-  [s]
+  "SHA-256 digest of the input as a byte array.
+
+  Accepts a byte array, or a string which is UTF-8 encoded first."
+  [bytes-or-str]
   #?(:clj (.digest (MessageDigest/getInstance "SHA-256")
-                   (.getBytes ^String s StandardCharsets/UTF_8))))
+                   (if (string? bytes-or-str)
+                     (.getBytes ^String bytes-or-str StandardCharsets/UTF_8)
+                     ^bytes bytes-or-str))))
+
+(defn hex-encode
+  "Lowercase hex string of the byte array."
+  [^bytes b]
+  #?(:clj (.formatHex (HexFormat/of) b)))
+
+(defn hex-decode
+  "Bytes from a hex string, or nil if invalid."
+  [s]
+  #?(:clj (try (.parseHex (HexFormat/of) ^String s) (catch Exception _))))
+
+(defn sha256-hex
+  "Lowercase hex string of (sha256 bytes-or-str)."
+  [bytes-or-str]
+  (hex-encode (sha256 bytes-or-str)))
 
 (defn base64-encode
-  [s]
-  #?(:clj (try (.encodeToString (Base64/getEncoder) ^String s) (catch Exception _))))
+  "Standard base64 (RFC 4648 §4) string of the byte array, without padding
+  (required by the atproto $bytes form). base64-decode accepts both padded
+  and unpadded input."
+  [^bytes b]
+  #?(:clj (.encodeToString (.withoutPadding (Base64/getEncoder)) b)))
 
 (defn base64-decode
   [s]
@@ -38,6 +60,11 @@
   "bytes -> url-safe base64 string."
   [^bytes bytes]
   #?(:clj (str (Base64URL/encode bytes))))
+
+(defn base64url-decode
+  "Decode a base64url string (padding optional) to bytes, or nil if invalid."
+  [s]
+  #?(:clj (try (.decode (Base64/getUrlDecoder) ^String s) (catch Exception _))))
 
 (defn generate-pkce
   "Proof Key for Code Exchange (S256) with a verifier of the given size."

--- a/src/atproto/runtime/jwt.cljc
+++ b/src/atproto/runtime/jwt.cljc
@@ -1,12 +1,19 @@
 (ns atproto.runtime.jwt
   "Cross platform JSON Web Token implementation for atproto."
-  #?(:clj (:require [clojure.walk :refer [stringify-keys keywordize-keys]]))
+  (:require [clojure.string :as str]
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.json :as json]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.crypto :as runtime.crypto]
+            [atproto.crypto :as crypto]
+            #?(:clj [clojure.walk :refer [stringify-keys keywordize-keys]]))
   #?(:clj (:import [java.util Map Set]
+                   [java.nio.charset StandardCharsets]
                    [com.nimbusds.jwt JWTClaimsSet$Builder SignedJWT]
                    [com.nimbusds.jose Algorithm JWSAlgorithm JWSHeader$Builder JOSEObjectType JWSSigner]
-                   [com.nimbusds.jose.jwk JWKSet JWK JWKSelector JWKMatcher JWKMatcher$Builder ECKey Curve KeyUse KeyType]
+                   [com.nimbusds.jose.jwk JWKSet JWK JWKSelector JWKMatcher JWKMatcher$Builder ECKey RSAKey Curve KeyUse KeyType]
                    [com.nimbusds.jose.jwk.gen JWKGenerator ECKeyGenerator OctetKeyPairGenerator RSAKeyGenerator]
-                   [com.nimbusds.jose.crypto.factories DefaultJWSSignerFactory])))
+                   [com.nimbusds.jose.crypto.factories DefaultJWSSignerFactory DefaultJWSVerifierFactory])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -101,3 +108,213 @@
                                          (clj->jwk jwk))]
             (.sign jwt signer)
             (.serialize jwt))))
+
+;; -----------------------------------------------------------------------------
+;; Compact JWS/JWT parsing, verification & signing (ES256/ES256K via
+;; atproto.crypto; the Nimbus-based `generate` above stays the OAuth/DPoP
+;; signing path).
+;; -----------------------------------------------------------------------------
+
+(defn- async-opts
+  "The async-adapter keys of an options map (see i/platform-async)."
+  [opts]
+  (select-keys opts [:channel :callback :promise]))
+
+(defn parse
+  "Split and decode a compact JWS/JWT WITHOUT verifying it.
+
+  Returns {:header {...}          ;; keywordized
+           :claims {...}          ;; keywordized (payload)
+           :signing-input bytes   ;; ASCII bytes of \"<b64h>.<b64p>\"
+           :signature bytes}      ;; base64url-decoded
+  or {:error \"MalformedJwt\" :message ...}."
+  [jwt-str]
+  #?(:clj
+     (let [parts (when (string? jwt-str) (str/split jwt-str #"\." -1))]
+       (if (not= 3 (count parts))
+         {:error "MalformedJwt"
+          :message "Expected three dot-separated base64url segments."}
+         (let [[h p sig] parts
+               header-bytes (runtime.crypto/base64url-decode h)
+               claims-bytes (runtime.crypto/base64url-decode p)
+               sig-bytes (runtime.crypto/base64url-decode sig)
+               header (when header-bytes
+                        (try (json/read-str (bytes/->utf8 header-bytes))
+                             (catch Exception _ nil)))
+               claims (when claims-bytes
+                        (try (json/read-str (bytes/->utf8 claims-bytes))
+                             (catch Exception _ nil)))]
+           (if (and (map? header) (map? claims) sig-bytes)
+             {:header header
+              :claims claims
+              :signing-input (.getBytes (str h "." p) StandardCharsets/US_ASCII)
+              :signature sig-bytes}
+             {:error "MalformedJwt"
+              :message "Could not decode the JWT header, claims, or signature."}))))))
+
+#?(:clj
+   (defn- ec-jwk->pubkey
+     "{:alg .. :bytes uncompressed-65-byte-pubkey} from a public EC JWK map,
+     or nil if it is not a well-formed P-256/secp256k1 JWK."
+     [{:keys [kty crv x y]}]
+     (let [alg ({"P-256" "ES256", "secp256k1" "ES256K"} crv)
+           ^bytes xb (when (string? x) (runtime.crypto/base64url-decode x))
+           ^bytes yb (when (string? y) (runtime.crypto/base64url-decode y))]
+       (when (and (= "EC" kty) alg
+                  xb yb (= 32 (alength xb)) (= 32 (alength yb)))
+         {:alg alg
+          :bytes (byte-array (concat [0x04] xb yb))}))))
+
+#?(:clj
+   (defn- verify-es-sig
+     "Verify the JWS signature against an ES256/ES256K public key.
+     Returns boolean or {:error ...}."
+     [{:keys [signing-input signature]} header-alg {key-alg :alg key-bytes :bytes} allow-malleable?]
+     (if (not= header-alg key-alg)
+       {:error "BadJwtSignature"
+        :message (str "JWT alg " header-alg " does not match key alg " key-alg ".")}
+       ;; atproto.crypto key operations are async; on the JVM they compute
+       ;; synchronously, so the promise is already delivered.
+       @(crypto/verify key-bytes signature signing-input
+                       :alg key-alg
+                       :allow-malleable? allow-malleable?))))
+
+#?(:clj
+   (defn- nimbus-verify
+     "Verify a compact JWS with a (non-ES256/ES256K) JWK via Nimbus.
+     Returns boolean or {:error ...}."
+     [jwt-str jwk]
+     (let [jwk-obj (clj->jwk jwk)
+           key (case (str (.getKeyType jwk-obj))
+                 "RSA" (.toRSAPublicKey ^RSAKey jwk-obj)
+                 "EC" (.toECPublicKey ^ECKey jwk-obj)
+                 nil)]
+       (if (nil? key)
+         {:error "UnsupportedAlgorithm"
+          :message "Unsupported JWK key type for verification."}
+         (try
+           (let [signed (SignedJWT/parse ^String jwt-str)
+                 verifier (.createJWSVerifier (DefaultJWSVerifierFactory.)
+                                              (.getHeader signed)
+                                              key)]
+             (.verify signed verifier))
+           (catch Exception _ false))))))
+
+#?(:clj
+   (defn- check-signature
+     "Boolean, or {:error ...} for problems distinct from an invalid signature."
+     [jwt-str {:keys [header] :as parsed} key allow-malleable?]
+     (let [alg (:alg header)]
+       (cond
+         (string? key)
+         (let [pk (crypto/did-key->pubkey key)]
+           (if (:error pk)
+             pk
+             (verify-es-sig parsed alg pk allow-malleable?)))
+
+         (:pubkey key)
+         (verify-es-sig parsed alg (:pubkey key) allow-malleable?)
+
+         (:jwk key)
+         (if (#{"ES256" "ES256K"} alg)
+           (if-let [pk (ec-jwk->pubkey (:jwk key))]
+             (verify-es-sig parsed alg pk allow-malleable?)
+             {:error "InvalidJwk"
+              :message "JWK is not a well-formed P-256/secp256k1 EC key."})
+           (nimbus-verify jwt-str (:jwk key)))
+
+         :else
+         {:error "UnsupportedKeyType"
+          :message "key must be a did:key string, {:pubkey ...}, or {:jwk ...}."}))))
+
+#?(:clj
+   (defn- verify-sync
+     [jwt-str key {:keys [now leeway] :or {leeway 0} :as opts}]
+     (let [allow-malleable? (if (contains? opts :allow-malleable?)
+                              (:allow-malleable? opts)
+                              true)
+           parsed (parse jwt-str)]
+       (if (:error parsed)
+         parsed
+         (let [{:keys [header claims]} parsed
+               now (or now (runtime.crypto/now))
+               {:keys [exp nbf iat]} claims]
+           (cond
+             (not (string? (:alg header)))
+             {:error "MalformedJwt"
+              :message "Missing or invalid \"alg\" header."}
+
+             (and (number? exp) (> now (+ exp leeway)))
+             {:error "JwtExpired" :message "jwt expired"}
+
+             (and (number? nbf) (< now (- nbf leeway)))
+             {:error "JwtNotYetValid" :message "jwt not valid yet (nbf)"}
+
+             (and (number? iat) (< now (- iat leeway)))
+             {:error "JwtNotYetValid" :message "jwt issued in the future (iat)"}
+
+             :else
+             (let [result (check-signature jwt-str parsed key allow-malleable?)]
+               (cond
+                 (map? result) result
+                 (true? result) {:header header :claims claims}
+                 :else {:error "BadJwtSignature"
+                        :message "JWT signature verification failed."}))))))))
+
+(defn verify
+  "Verify a compact JWS/JWT's signature and temporal claims.
+
+  `key` is one of:
+    - a did:key string                       (ES256/ES256K via atproto.crypto)
+    - {:pubkey {:alg .. :bytes ..}}          (ES256/ES256K raw key)
+    - {:jwk {...}}                           (delegates to Nimbus for other algs)
+
+  opts:
+    :now              epoch seconds (default (runtime.crypto/now)) — for tests
+    :leeway           seconds of clock skew tolerance (default 0)
+    :allow-malleable? for ES256/ES256K sig checks (default true — matches
+                      the reference service-JWT verification,
+                      xrpc-server/src/auth.ts cryptoVerifySignatureWithKey;
+                      pass false for strict atproto signature rules)
+
+  Checks: signature over the signing input; :exp (expired → error);
+  :nbf/:iat when present. Does NOT check aud/iss/lxm/typ — callers
+  (WS-08 service auth) layer policy on the returned claims.
+
+  Async; yields {:header {...} :claims {...}}
+  or {:error \"MalformedJwt\"|\"BadJwtSignature\"|\"JwtExpired\"|
+      \"UnsupportedAlgorithm\" ... :message ...}."
+  [jwt-str key & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (cb #?(:clj (verify-sync jwt-str key opts)
+           :cljs {:error "NotImplemented"
+                  :message "JWT verification is not yet implemented on ClojureScript."}))
+    val))
+
+(defn sign
+  "Compact JWS signed with an atproto.crypto Keypair (ES256/ES256K):
+  base64url(JSON header) \".\" base64url(JSON claims) \".\" base64url(64-byte sig).
+  The :alg header is set from (crypto/alg keypair); the ES256/ES256K JWS
+  signature is exactly the 64-byte compact signature (RFC 7518 §3.4,
+  RFC 8812 §3.2). Mirrors the reference createServiceJwt encoding.
+
+  Async; yields the compact JWS string."
+  [keypair headers claims & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    #?(:clj
+       (let [b64url (fn [^String s]
+                      (runtime.crypto/base64url-encode
+                       (.getBytes s StandardCharsets/UTF_8)))
+             header (assoc headers :alg (crypto/alg keypair))
+             h64 (b64url (json/write-str header))
+             p64 (b64url (json/write-str claims))
+             signing-input (.getBytes (str h64 "." p64) StandardCharsets/US_ASCII)]
+         (crypto/sign keypair signing-input
+                      :callback (fn [sig]
+                                  (cb (if (:error sig)
+                                        sig
+                                        (str h64 "." p64 "."
+                                             (runtime.crypto/base64url-encode sig)))))))
+       :cljs (cb {:error "NotImplemented"
+                  :message "JWT signing with atproto.crypto keypairs is not yet implemented on ClojureScript."}))
+    val))

--- a/test/atproto/crypto_test.cljc
+++ b/test/atproto/crypto_test.cljc
@@ -1,0 +1,253 @@
+(ns atproto.crypto-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [multiformats.base :as mb]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.json :as json]
+            [atproto.crypto :as crypto])
+  #?(:clj (:import [java.math BigInteger]
+                   [java.util Arrays Base64])))
+
+(def algs ["ES256" "ES256K"])
+
+;; Curve orders, for low-S assertions.
+(def curve-order
+  {"ES256" (BigInteger. "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551" 16)
+   "ES256K" (BigInteger. "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141" 16)})
+
+(defn- load-fixture
+  [path]
+  (json/read-str (slurp (io/resource (str "interop-test-files/crypto/" path)))))
+
+(defn- b64-decode
+  "Decode standard base64 without padding (the fixture encoding)."
+  ^bytes [s]
+  #?(:clj (.decode (Base64/getDecoder) ^String s)))
+
+(defn- result-of
+  [async-val]
+  (deref async-val 1000 ::timeout))
+
+;; -----------------------------------------------------------------------------
+;; Keypairs
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest keypair-test
+     (doseq [alg algs]
+       (testing (str alg " sign/verify round-trip")
+         (let [kp (result-of (crypto/generate alg))
+               msg (.getBytes "hello world" "UTF-8")
+               sig (result-of (crypto/sign kp msg))]
+           (is (= alg (crypto/alg kp)))
+           (is (= 33 (alength ^bytes (crypto/public-key kp))))
+           (is (= 64 (alength ^bytes sig)))
+           (is (true? (result-of (crypto/verify (crypto/public-key kp) sig msg :alg alg))))
+           (testing "mutated message fails"
+             (is (false? (result-of (crypto/verify (crypto/public-key kp) sig
+                                                   (.getBytes "hello world!" "UTF-8")
+                                                   :alg alg)))))
+           (testing "mutated signature fails"
+             (let [bad (Arrays/copyOf ^bytes sig 64)]
+               (aset bad 50 (unchecked-byte (bit-xor (aget bad 50) 0xff)))
+               (is (false? (result-of (crypto/verify (crypto/public-key kp) bad msg :alg alg))))))))
+       (testing (str alg " export/import preserves did")
+         (let [kp (result-of (crypto/generate alg :exportable? true))
+               priv (crypto/export kp)
+               imported (result-of (crypto/import-private-key alg priv))]
+           (is (= 32 (alength ^bytes priv)))
+           (is (= (crypto/did kp) (crypto/did imported)))
+           (testing "and from a hex string (TS parity)"
+             (let [hex (apply str (map #(format "%02x" %) priv))
+                   from-hex (result-of (crypto/import-private-key alg hex))]
+               (is (= (crypto/did kp) (crypto/did from-hex)))))))
+       (testing (str alg " non-exportable keypair refuses export")
+         (let [kp (result-of (crypto/generate alg))]
+           (is (= "PrivateKeyNotExportable" (:error (crypto/export kp))))
+           (is (= "PrivateKeyNotExportable" (:error (crypto/keypair->jwk kp))))))
+       (testing (str alg " JWK round-trip")
+         (let [kp (result-of (crypto/generate alg :exportable? true))
+               jwk (crypto/keypair->jwk kp)
+               kp2 (crypto/jwk->keypair jwk)]
+           (is (= "EC" (:kty jwk)))
+           (is (= ({"ES256" "P-256" "ES256K" "secp256k1"} alg) (:crv jwk)))
+           (is (= (crypto/did kp) (crypto/did kp2))))))
+     (testing "error cases"
+       (is (= "UnsupportedAlgorithm" (:error (result-of (crypto/generate "ES512")))))
+       (is (= "UnsupportedAlgorithm" (:error (result-of (crypto/import-private-key "RS256" (byte-array 32))))))
+       (is (= "InvalidPrivateKey" (:error (result-of (crypto/import-private-key "ES256" (byte-array 31))))))
+       (is (= "InvalidPrivateKey" (:error (result-of (crypto/import-private-key "ES256" (byte-array 32))))))
+       (is (= "InvalidPrivateKey" (:error (result-of (crypto/import-private-key "ES256" "not-hex")))))
+       (is (= "InvalidJwk" (:error (crypto/jwk->keypair {:kty "RSA"}))))
+       (is (= "InvalidJwk" (:error (crypto/jwk->keypair {:kty "EC" :crv "P-256"})))))))
+
+;; -----------------------------------------------------------------------------
+;; Key compression
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest key-compression-test
+     (doseq [alg algs]
+       (testing (str alg " compressed <-> uncompressed round-trips")
+         (dotimes [_ 100]
+           (let [kp (result-of (crypto/generate alg))
+                 ^bytes compressed (crypto/public-key kp)
+                 ^bytes uncompressed (crypto/decompress-pubkey alg compressed)]
+             (is (= 33 (alength compressed)))
+             (is (= 65 (alength uncompressed)))
+             (is (= 0x04 (aget uncompressed 0)))
+             (is (bytes/eq? compressed (crypto/compress-pubkey alg uncompressed)))
+             ;; compress-pubkey accepts either form
+             (is (bytes/eq? compressed (crypto/compress-pubkey alg compressed)))))))
+     (testing "error cases"
+       (is (= "InvalidPublicKey" (:error (crypto/decompress-pubkey "ES256" (byte-array 65)))))
+       ;; x = 2^256 - 1 is not a valid field element on either curve
+       (let [bad (byte-array (cons 0x02 (repeat 32 -1)))]
+         (is (= "InvalidPublicKey" (:error (crypto/decompress-pubkey "ES256" bad))))
+         (is (= "InvalidPublicKey" (:error (crypto/compress-pubkey "ES256K" bad)))))
+       (is (= "UnsupportedAlgorithm" (:error (crypto/compress-pubkey "EdDSA" (byte-array 33))))))))
+
+;; -----------------------------------------------------------------------------
+;; did:key W3C test vectors
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest didkey-w3c-vectors-test
+     (testing "secp256k1 vectors (hex private keys)"
+       (let [vectors (load-fixture "w3c_didkey_K256.json")]
+         (is (= 5 (count vectors)))
+         (doseq [{:keys [privateKeyBytesHex publicDidKey]} vectors]
+           (let [kp (result-of (crypto/import-private-key "ES256K" privateKeyBytesHex))]
+             (is (= publicDidKey (crypto/did kp)))))))
+     (testing "P-256 vectors (base58btc private keys)"
+       (let [vectors (load-fixture "w3c_didkey_P256.json")]
+         (is (= 1 (count vectors)))
+         (doseq [{:keys [privateKeyBytesBase58 publicDidKey]} vectors]
+           (let [priv (mb/parse* :base58btc privateKeyBytesBase58)
+                 kp (result-of (crypto/import-private-key "ES256" priv))]
+             (is (= publicDidKey (crypto/did kp)))))))))
+
+#?(:clj
+   (deftest didkey-round-trip-test
+     (doseq [alg algs]
+       (testing (str alg " pubkey->did-key / did-key->pubkey round-trip")
+         (let [kp (result-of (crypto/generate alg))
+               ^bytes compressed (crypto/public-key kp)
+               did (crypto/pubkey->did-key alg compressed)
+               {parsed-alg :alg ^bytes parsed-bytes :bytes} (crypto/did-key->pubkey did)]
+           (is (string? did))
+           (is (str/starts-with? did "did:key:z"))
+           (is (= alg parsed-alg))
+           ;; parsing returns the uncompressed (65-byte) key
+           (is (= 65 (alength parsed-bytes)))
+           (is (bytes/eq? compressed (crypto/compress-pubkey alg parsed-bytes)))
+           ;; uncompressed input formats to the same did
+           (is (= did (crypto/pubkey->did-key alg parsed-bytes)))
+           ;; multikey helpers compose with the did:key fns
+           (is (= did (str "did:key:" (crypto/format-multikey alg compressed))))
+           (is (= alg (:alg (crypto/parse-multikey (subs did (count "did:key:")))))))))))
+
+#?(:clj
+   (deftest didkey-error-test
+     (testing "ed25519 did:key is unsupported"
+       (is (= "UnsupportedKeyType"
+              (:error (crypto/did-key->pubkey
+                       "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")))))
+     (testing "non-base58btc multibase"
+       (is (= "InvalidDidKey" (:error (crypto/did-key->pubkey "did:key:uAAAA"))))
+       (is (= "InvalidDidKey" (:error (crypto/parse-multikey "uAAAA")))))
+     (testing "missing did:key prefix"
+       (is (= "InvalidDidKey" (:error (crypto/did-key->pubkey "did:web:example.com"))))
+       (is (= "InvalidDidKey" (:error (crypto/did-key->pubkey nil)))))
+     (testing "invalid base58 payload"
+       (is (= "InvalidDidKey" (:error (crypto/did-key->pubkey "did:key:z0OIl")))))))
+
+;; -----------------------------------------------------------------------------
+;; Signature interop vectors (the core parity test)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest signature-fixtures-test
+     (let [vectors (load-fixture "signature-fixtures.json")]
+       (is (= 6 (count vectors)))
+       (doseq [{:keys [comment messageBase64 algorithm publicKeyDid publicKeyMultibase
+                       signatureBase64 validSignature tags]} vectors]
+         (let [msg (b64-decode messageBase64)
+               sig (b64-decode signatureBase64)
+               multibase-key (crypto/multibase->bytes publicKeyMultibase)
+               {:keys [alg bytes]} (crypto/did-key->pubkey publicKeyDid)]
+           (testing (str comment ": multibase key matches the did:key")
+             (is (= algorithm alg))
+             (is (bytes/eq? multibase-key (crypto/compress-pubkey alg bytes))))
+           (testing (str comment ": strict verify matches validSignature")
+             (is (= validSignature
+                    (result-of (crypto/verify multibase-key sig msg :alg algorithm))))
+             (is (= validSignature
+                    (result-of (crypto/verify-did-sig publicKeyDid sig msg)))))
+           (when (seq tags)
+             (testing (str comment ": malleable verify accepts " (pr-str tags))
+               (is (true? (result-of (crypto/verify multibase-key sig msg
+                                                    :alg algorithm
+                                                    :allow-malleable? true))))
+               (is (true? (result-of (crypto/verify-did-sig publicKeyDid sig msg
+                                                            :allow-malleable? true)))))))))))
+
+;; -----------------------------------------------------------------------------
+;; Negative & edge cases
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest verify-edge-cases-test
+     (let [kp (result-of (crypto/generate "ES256"))
+           msg (.getBytes "edge cases" "UTF-8")
+           ^bytes sig (result-of (crypto/sign kp msg))]
+       (testing "wrong :alg for the key never verifies"
+         (is (not (true? (result-of (crypto/verify (crypto/public-key kp) sig msg
+                                                   :alg "ES256K"))))))
+       (testing "alg assertion mismatch on verify-did-sig"
+         (is (= "AlgorithmMismatch"
+                (:error (result-of (crypto/verify-did-sig (crypto/did kp) sig msg
+                                                          :alg "ES256K"))))))
+       (testing "wrong-length signatures are false, not errors"
+         (is (false? (result-of (crypto/verify (crypto/public-key kp)
+                                               (Arrays/copyOf sig 63) msg :alg "ES256"))))
+         (is (false? (result-of (crypto/verify (crypto/public-key kp)
+                                               (Arrays/copyOf sig 65) msg :alg "ES256"))))
+         (is (false? (result-of (crypto/verify (crypto/public-key kp)
+                                               (byte-array 0) msg :alg "ES256")))))
+       (testing "unsupported alg and invalid pubkey are errors, not false"
+         (is (= "UnsupportedAlgorithm"
+                (:error (result-of (crypto/verify (crypto/public-key kp) sig msg)))))
+         (is (= "InvalidPublicKey"
+                (:error (result-of (crypto/verify (byte-array 33) sig msg :alg "ES256")))))))))
+
+#?(:clj
+   (deftest low-s-and-determinism-test
+     (doseq [alg algs]
+       (testing (str alg " signatures are low-S and deterministic")
+         (let [kp (result-of (crypto/generate alg))
+               ^BigInteger n (curve-order alg)
+               half (.shiftRight n 1)]
+           (dotimes [i 25]
+             (let [msg (.getBytes (str "message " i) "UTF-8")
+                   ^bytes sig (result-of (crypto/sign kp msg))
+                   s (BigInteger. 1 (Arrays/copyOfRange sig 32 64))]
+               (is (= 64 (alength sig)))
+               (is (<= (.compareTo s half) 0))
+               (is (true? (result-of (crypto/verify (crypto/public-key kp) sig msg :alg alg))))
+               (testing "RFC 6979: signing twice yields identical bytes"
+                 (is (bytes/eq? sig (result-of (crypto/sign kp msg))))))))))))
+
+;; -----------------------------------------------------------------------------
+;; Multibase wrappers
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest multibase-test
+     (let [b (byte-array [1 2 3 4 5])]
+       (doseq [base [:base16 :base32 :base58btc :base64 :base64url]]
+         (let [s (crypto/bytes->multibase base b)]
+           (is (bytes/eq? b (crypto/multibase->bytes s))))))
+     (is (= "InvalidMultibase" (:error (crypto/multibase->bytes "?abc"))))))

--- a/test/atproto/crypto_test.cljc
+++ b/test/atproto/crypto_test.cljc
@@ -3,6 +3,9 @@
                :cljs [cljs.test :refer :all])
             [clojure.java.io :as io]
             [clojure.string :as str]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
             [multiformats.base :as mb]
             [atproto.runtime.bytes :as bytes]
             [atproto.runtime.json :as json]
@@ -89,18 +92,7 @@
 
 #?(:clj
    (deftest key-compression-test
-     (doseq [alg algs]
-       (testing (str alg " compressed <-> uncompressed round-trips")
-         (dotimes [_ 100]
-           (let [kp (result-of (crypto/generate alg))
-                 ^bytes compressed (crypto/public-key kp)
-                 ^bytes uncompressed (crypto/decompress-pubkey alg compressed)]
-             (is (= 33 (alength compressed)))
-             (is (= 65 (alength uncompressed)))
-             (is (= 0x04 (aget uncompressed 0)))
-             (is (bytes/eq? compressed (crypto/compress-pubkey alg uncompressed)))
-             ;; compress-pubkey accepts either form
-             (is (bytes/eq? compressed (crypto/compress-pubkey alg compressed)))))))
+     ;; the round-trip itself is covered generatively below
      (testing "error cases"
        (is (= "InvalidPublicKey" (:error (crypto/decompress-pubkey "ES256" (byte-array 65)))))
        ;; x = 2^256 - 1 is not a valid field element on either curve
@@ -108,6 +100,61 @@
          (is (= "InvalidPublicKey" (:error (crypto/decompress-pubkey "ES256" bad))))
          (is (= "InvalidPublicKey" (:error (crypto/compress-pubkey "ES256K" bad)))))
        (is (= "UnsupportedAlgorithm" (:error (crypto/compress-pubkey "EdDSA" (byte-array 33))))))))
+
+;; -----------------------------------------------------------------------------
+;; Generative properties (test.check)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (def gen-keypair
+     "[alg Keypair] from a random 32-byte private scalar (discarding the
+     astronomically rare out-of-range scalars instead of shrinking on them)."
+     (gen/such-that
+      (fn [[_ kp]] (not (map? kp)))
+      (gen/fmap (fn [[alg bs]]
+                  [alg (result-of (crypto/import-private-key alg (byte-array bs)))])
+                (gen/tuple (gen/elements algs)
+                           (gen/vector (gen/choose 0 255) 32))))))
+
+#?(:clj
+   (defspec key-compression-round-trip-spec 100
+     (prop/for-all [[alg kp] gen-keypair]
+       (let [^bytes compressed (crypto/public-key kp)
+             ^bytes uncompressed (crypto/decompress-pubkey alg compressed)]
+         (and (= 33 (alength compressed))
+              (= 65 (alength uncompressed))
+              (= 0x04 (aget uncompressed 0))
+              (bytes/eq? compressed (crypto/compress-pubkey alg uncompressed))
+              ;; compress-pubkey accepts either form
+              (bytes/eq? compressed (crypto/compress-pubkey alg compressed)))))))
+
+#?(:clj
+   (defspec sign-verify-low-s-deterministic-spec 30
+     (prop/for-all [[alg kp] gen-keypair
+                    msg gen/bytes]
+       (let [^bytes sig (result-of (crypto/sign kp msg))
+             s (BigInteger. 1 (Arrays/copyOfRange sig 32 64))
+             ^BigInteger n (curve-order alg)]
+         (and (= 64 (alength sig))
+              ;; low-S: s <= n/2
+              (<= (.compareTo s (.shiftRight n 1)) 0)
+              ;; own sigs verify strictly
+              (true? (result-of (crypto/verify (crypto/public-key kp) sig msg :alg alg)))
+              ;; RFC 6979: deterministic
+              (bytes/eq? sig (result-of (crypto/sign kp msg))))))))
+
+#?(:clj
+   (defspec did-key-round-trip-spec 100
+     (prop/for-all [[alg kp] gen-keypair]
+       (let [did (crypto/did kp)
+             {parsed-alg :alg ^bytes parsed-bytes :bytes} (crypto/did-key->pubkey did)]
+         (and (str/starts-with? did "did:key:z")
+              (= alg parsed-alg)
+              (= 65 (alength parsed-bytes))
+              (bytes/eq? (crypto/public-key kp)
+                         (crypto/compress-pubkey alg parsed-bytes))
+              ;; formatting the parsed (uncompressed) key yields the same did
+              (= did (crypto/pubkey->did-key alg parsed-bytes)))))))
 
 ;; -----------------------------------------------------------------------------
 ;; did:key W3C test vectors
@@ -222,23 +269,6 @@
                 (:error (result-of (crypto/verify (crypto/public-key kp) sig msg)))))
          (is (= "InvalidPublicKey"
                 (:error (result-of (crypto/verify (byte-array 33) sig msg :alg "ES256")))))))))
-
-#?(:clj
-   (deftest low-s-and-determinism-test
-     (doseq [alg algs]
-       (testing (str alg " signatures are low-S and deterministic")
-         (let [kp (result-of (crypto/generate alg))
-               ^BigInteger n (curve-order alg)
-               half (.shiftRight n 1)]
-           (dotimes [i 25]
-             (let [msg (.getBytes (str "message " i) "UTF-8")
-                   ^bytes sig (result-of (crypto/sign kp msg))
-                   s (BigInteger. 1 (Arrays/copyOfRange sig 32 64))]
-               (is (= 64 (alength sig)))
-               (is (<= (.compareTo s half) 0))
-               (is (true? (result-of (crypto/verify (crypto/public-key kp) sig msg :alg alg))))
-               (testing "RFC 6979: signing twice yields identical bytes"
-                 (is (bytes/eq? sig (result-of (crypto/sign kp msg))))))))))))
 
 ;; -----------------------------------------------------------------------------
 ;; Multibase wrappers

--- a/test/atproto/runtime/crypto_test.cljc
+++ b/test/atproto/runtime/crypto_test.cljc
@@ -1,0 +1,62 @@
+(ns atproto.runtime.crypto-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [clojure.string :as str]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.crypto :as crypto]))
+
+;; sha256 of "abc", see https://www.di-mgt.com.au/sha_testvectors.html
+(def sha256-abc-hex
+  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+
+#?(:clj
+   (deftest sha256-test
+     (testing "accepts strings and byte arrays equivalently"
+       (is (bytes/eq? (crypto/sha256 "abc")
+                      (crypto/sha256 (.getBytes "abc" "UTF-8")))))
+     (testing "known test vector"
+       (is (= sha256-abc-hex (crypto/hex-encode (crypto/sha256 "abc"))))
+       (is (= sha256-abc-hex (crypto/sha256-hex "abc")))
+       (is (= sha256-abc-hex (crypto/sha256-hex (.getBytes "abc" "UTF-8")))))))
+
+#?(:clj
+   (deftest base64-test
+     (testing "round-trips byte arrays"
+       (dotimes [_ 20]
+         (let [b (crypto/random-bytes (inc (rand-int 64)))]
+           (is (bytes/eq? b (crypto/base64-decode (crypto/base64-encode b)))))))
+     (testing "encodes without padding"
+       (is (= "QQ" (crypto/base64-encode (byte-array [(int \A)]))))
+       (is (not (str/includes? (crypto/base64-encode (crypto/random-bytes 10)) "="))))
+     (testing "decodes padded and unpadded input"
+       (is (bytes/eq? (byte-array [(int \A)]) (crypto/base64-decode "QQ")))
+       (is (bytes/eq? (byte-array [(int \A)]) (crypto/base64-decode "QQ=="))))
+     (testing "returns nil on invalid input"
+       (is (nil? (crypto/base64-decode "&&&&"))))))
+
+#?(:clj
+   (deftest base64url-test
+     (testing "round-trips byte arrays"
+       (dotimes [_ 20]
+         (let [b (crypto/random-bytes (inc (rand-int 64)))]
+           (is (bytes/eq? b (crypto/base64url-decode (crypto/base64url-encode b)))))))
+     (testing "decodes padded and unpadded input"
+       (is (bytes/eq? (byte-array [(unchecked-byte 0xfb)]) (crypto/base64url-decode "-w")))
+       (is (bytes/eq? (byte-array [(unchecked-byte 0xfb)]) (crypto/base64url-decode "-w=="))))
+     (testing "returns nil on invalid input"
+       (is (nil? (crypto/base64url-decode "+/+/"))))))
+
+#?(:clj
+   (deftest hex-test
+     (testing "round-trips byte arrays"
+       (dotimes [_ 20]
+         (let [b (crypto/random-bytes (inc (rand-int 64)))]
+           (is (bytes/eq? b (crypto/hex-decode (crypto/hex-encode b)))))))
+     (testing "encodes lowercase"
+       (is (= "00ff10" (crypto/hex-encode (byte-array [0x00 (unchecked-byte 0xff) 0x10])))))
+     (testing "decodes uppercase and lowercase"
+       (is (bytes/eq? (byte-array [(unchecked-byte 0xab)]) (crypto/hex-decode "AB")))
+       (is (bytes/eq? (byte-array [(unchecked-byte 0xab)]) (crypto/hex-decode "ab"))))
+     (testing "returns nil on invalid input"
+       (is (nil? (crypto/hex-decode "zz")))
+       (is (nil? (crypto/hex-decode "abc"))))))

--- a/test/atproto/runtime/jwt_test.cljc
+++ b/test/atproto/runtime/jwt_test.cljc
@@ -1,0 +1,143 @@
+(ns atproto.runtime.jwt-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [clojure.string :as str]
+            [atproto.runtime.crypto :as runtime.crypto]
+            [atproto.runtime.jwt :as jwt]
+            [atproto.crypto :as crypto])
+  #?(:clj (:import [java.math BigInteger]
+                   [java.util Arrays])))
+
+(defn- result-of
+  [async-val]
+  (deref async-val 1000 ::timeout))
+
+(def claims
+  {:iss "did:example:alice"
+   :aud "did:example:bob"
+   :lxm "com.example.method"
+   :exp 4102444800}) ;; 2100-01-01
+
+#?(:clj
+   (deftest parse-test
+     (let [kp (result-of (crypto/generate "ES256K"))
+           token (result-of (jwt/sign kp {:typ "JWT"} claims))
+           parsed (jwt/parse token)]
+       (testing "decodes header, claims, signing input, and signature"
+         (is (= {:typ "JWT" :alg "ES256K"} (:header parsed)))
+         (is (= claims (:claims parsed)))
+         (is (= (str/join "." (take 2 (str/split token #"\.")))
+                (String. ^bytes (:signing-input parsed) "US-ASCII")))
+         (is (= 64 (alength ^bytes (:signature parsed)))))
+       (testing "malformed input"
+         (doseq [bad [nil 42 "" "garbage" "a.b" "a.b.c.d" "!!.??.~~"]]
+           (is (= "MalformedJwt" (:error (jwt/parse bad))) (pr-str bad)))))))
+
+#?(:clj
+   (deftest sign-verify-round-trip-test
+     (doseq [alg ["ES256" "ES256K"]]
+       (let [kp (result-of (crypto/generate alg))
+             token (result-of (jwt/sign kp {:typ "JWT"} claims))]
+         (testing (str alg " verify with the did:key string")
+           (let [res (result-of (jwt/verify token (crypto/did kp)))]
+             (is (nil? (:error res)))
+             (is (= claims (:claims res)))
+             (is (= alg (-> res :header :alg)))))
+         (testing (str alg " verify with {:pubkey ...}")
+           (let [res (result-of (jwt/verify token {:pubkey {:alg alg
+                                                            :bytes (crypto/public-key kp)}}))]
+             (is (= claims (:claims res)))))
+         (testing (str alg " verify with a public EC {:jwk ...}")
+           (let [exportable (result-of (crypto/import-private-key
+                                        alg (crypto/export (result-of (crypto/generate alg :exportable? true)))
+                                        :exportable? true))
+                 token2 (result-of (jwt/sign exportable {:typ "JWT"} claims))
+                 public-jwk (dissoc (crypto/keypair->jwk exportable) :d)
+                 res (result-of (jwt/verify token2 {:jwk public-jwk}))]
+             (is (= claims (:claims res)))))
+         (testing (str alg " wrong key fails")
+           (let [other (result-of (crypto/generate alg))]
+             (is (= "BadJwtSignature"
+                    (:error (result-of (jwt/verify token (crypto/did other))))))))))))
+
+#?(:clj
+   (deftest verify-nimbus-cross-check-test
+     (testing "verifies an ES256 token produced by the Nimbus-based generate"
+       (let [jwk (jwt/generate-jwk {:alg "ES256" :kid "test-key"})
+             token (jwt/generate jwk {:alg "ES256" :typ "JWT"} claims)
+             res (result-of (jwt/verify token {:jwk (jwt/public-jwk jwk)}))]
+         (is (nil? (:error res)))
+         (is (= "did:example:alice" (-> res :claims :iss)))))
+     (testing "delegates non-ES256K algs to Nimbus"
+       (let [jwk (jwt/generate-jwk {:alg "RS256" :kid "rsa-key"})
+             token (jwt/generate jwk {:alg "RS256" :typ "JWT"} claims)
+             res (result-of (jwt/verify token {:jwk (jwt/public-jwk jwk)}))]
+         (is (nil? (:error res)))
+         (is (= claims (:claims res)))))))
+
+#?(:clj
+   (deftest verify-temporal-claims-test
+     (let [kp (result-of (crypto/generate "ES256K"))
+           did (crypto/did kp)
+           token (result-of (jwt/sign kp {:typ "JWT"} {:iss "x" :exp 1000}))]
+       (testing "expired token"
+         (is (= "JwtExpired" (:error (result-of (jwt/verify token did :now 2000))))))
+       (testing "not yet expired"
+         (is (nil? (:error (result-of (jwt/verify token did :now 500))))))
+       (testing "leeway tolerates clock skew"
+         (is (nil? (:error (result-of (jwt/verify token did :now 1010 :leeway 30))))))
+       (testing "nbf in the future"
+         (let [token (result-of (jwt/sign kp {:typ "JWT"} {:iss "x" :nbf 1000}))]
+           (is (= "JwtNotYetValid" (:error (result-of (jwt/verify token did :now 500)))))
+           (is (nil? (:error (result-of (jwt/verify token did :now 1500))))))))))
+
+#?(:clj
+   (deftest verify-tampering-test
+     (let [kp (result-of (crypto/generate "ES256K"))
+           did (crypto/did kp)
+           token (result-of (jwt/sign kp {:typ "JWT"} claims))
+           [h p sig] (str/split token #"\.")]
+       (testing "tampered payload"
+         (let [evil (runtime.crypto/base64url-encode
+                     (.getBytes "{\"iss\":\"did:example:mallory\"}" "UTF-8"))]
+           (is (= "BadJwtSignature"
+                  (:error (result-of (jwt/verify (str h "." evil "." sig) did)))))))
+       (testing "tampered signature"
+         (let [^bytes sig-bytes (runtime.crypto/base64url-decode sig)
+               _ (aset sig-bytes 10 (unchecked-byte (bit-xor (aget sig-bytes 10) 0xff)))
+               bad (runtime.crypto/base64url-encode sig-bytes)]
+           (is (= "BadJwtSignature"
+                  (:error (result-of (jwt/verify (str h "." p "." bad) did))))))))))
+
+;; secp256k1 curve order, for constructing a high-S variant of a valid sig.
+(def ^:private k256-n
+  #?(:clj (BigInteger. "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141" 16)))
+
+#?(:clj
+   (deftest verify-malleability-default-test
+     ;; Service JWTs are verified leniently in the reference implementation
+     ;; (xrpc-server/src/auth.ts cryptoVerifySignatureWithKey passes
+     ;; allowMalleableSig: true), so jwt/verify defaults :allow-malleable? true.
+     (let [kp (result-of (crypto/generate "ES256K"))
+           did (crypto/did kp)
+           token (result-of (jwt/sign kp {:typ "JWT"} claims))
+           [h p sig] (str/split token #"\.")
+           ^bytes sig-bytes (runtime.crypto/base64url-decode sig)
+           s (BigInteger. 1 (Arrays/copyOfRange sig-bytes 32 64))
+           ^bytes high-s (.toByteArray (.subtract k256-n s))
+           ;; left-pad/strip to exactly 32 bytes
+           high-s (let [out (byte-array 32)
+                        len (alength high-s)]
+                    (if (<= len 32)
+                      (System/arraycopy high-s 0 out (- 32 len) len)
+                      (System/arraycopy high-s (- len 32) out 0 32))
+                    out)
+           malleated (byte-array 64)]
+       (System/arraycopy sig-bytes 0 malleated 0 32)
+       (System/arraycopy high-s 0 malleated 32 32)
+       (let [bad-token (str h "." p "." (runtime.crypto/base64url-encode malleated))]
+         (testing "high-S signature verifies by default (service-JWT parity)"
+           (is (nil? (:error (result-of (jwt/verify bad-token did))))))
+         (testing "high-S signature is rejected with :allow-malleable? false"
+           (is (= "BadJwtSignature"
+                  (:error (result-of (jwt/verify bad-token did :allow-malleable? false))))))))))


### PR DESCRIPTION
Implements [docs/planning/03-crypto.md](docs/planning/03-crypto.md) (WS-03, P0), following the reference implementation at `bluesky-social/atproto` pinned at `b9ef557`. This freezes the §4.2 interface contract that WS-04, WS-06, and WS-08 build on.

## What's in here

**1. `atproto.runtime.crypto` fixes** (doc milestone PR 1)
- `sha256` accepts byte arrays as well as strings (everything in atproto signs bytes)
- `base64-encode`: fixed the broken `^String` type hint (was silently reflecting) and now emits **unpadded** output per 00-overview §4.9 item 4; `base64-decode` accepts padded and unpadded
- new `base64url-decode`, `hex-encode`/`hex-decode`, `sha256-hex`
- existing OAuth/DPoP and `atproto.data.json` callers unchanged and still green

**2. New `atproto.crypto` namespace** (doc milestones PR 2 + PR 3)
- BouncyCastle lightweight API (no global `Security/addProvider` mutation); `org.bouncycastle/bcprov-jdk18on 1.80` added to deps.edn
- keypair generate/import/export (`:exportable?`-gated) + EC JWK round-trips for both curves (ES256 / P-256 and ES256K / secp256k1)
- `sign`: 64-byte compact low-S signatures over `sha256(msg)` with RFC 6979 deterministic nonces (parity with `@noble/curves`)
- `verify` / `verify-did-sig`: strict by default (exactly 64-byte compact + low-S), `:allow-malleable?` accepts DER and high-S (noble parity: DER tried first, then compact)
- `compress-pubkey`/`decompress-pubkey` with on-curve validation; did:key / multikey encode-decode (P-256 prefix `0x80 0x24`, secp256k1 `0xe7 0x01`); thin multibase wrappers over `multiformats.base`
- key operations are **async** per the SDK callback convention (§4.2, decided 2026-06-10); JVM bodies compute synchronously and adapt via `platform-async`. Accessors (`alg`/`public-key`/`did`) and parsing/encoding stay sync.

**3. `atproto.runtime.jwt` additions** (doc milestone PR 4)
- `parse` (no verification), `verify`, `sign` for compact JWS, hand-rolled over `atproto.crypto` (the ES256/ES256K JWS sig is exactly the 64-byte compact sig, RFC 7518 §3.4 / RFC 8812 §3.2)
- `verify` keys: did:key string, `{:pubkey {:alg .. :bytes ..}}`, or `{:jwk {...}}` (delegates to Nimbus for non-ES algs); temporal checks `:exp`/`:nbf`/`:iat` with `:now`/`:leeway` opts; **no** aud/iss/lxm/typ policy — that's WS-08's layer
- `:allow-malleable?` defaults `true` for service-JWT parity (`xrpc-server/src/auth.ts` passes `allowMalleableSig: true`); WS-08 confirms this default when implementing policy (open question 8)
- existing Nimbus `generate`/JWK fns untouched (OAuth/DPoP path)

## Test coverage

`clojure -X:test`: 66 tests, 2324 assertions, 0 failures. No reflection warnings in touched namespaces.

- all 6 vendored interop signature vectors: strict `verify` matches `validSignature` exactly; the `high-s`/`der-encoded` vectors verify `true` with `:allow-malleable? true`
- all W3C did:key vectors (5 × K-256 hex keys, 1 × P-256 base58 key) derive the expected did:key
- 100-key compression round-trips per curve; low-S + RFC 6979 determinism properties
- negative cases per the doc: ed25519 did:key → `UnsupportedKeyType`, non-`z` multibase → `InvalidDidKey`, off-curve keys → `InvalidPublicKey`, wrong-length sigs → `false`
- JWT: both curves round-trip through all three key forms; Nimbus-generated ES256 and RS256 tokens verified by the new `verify`; expiry/nbf/leeway; tampered payload/sig; high-S variant verifies by default and is rejected with `:allow-malleable? false`

## Decisions / notes for the orchestrator

- **Tink left in deps.edn** — its removal is an explicit open question (doc risk 6); trivial follow-up commit if approved
- error names the doc left unspecified: `AlgorithmMismatch` (verify-did-sig `:alg` assertion failure) and `JwtNotYetValid` (future `nbf`/`iat`)
- cljs bodies are absent / yield `{:error "NotImplemented"}` — WebCrypto/@noble backend is WS-10's documented stretch goal; the async API leaves the seam open

https://claude.ai/code/session_01Law8oQoKDcoJ9H3uWUzYFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Law8oQoKDcoJ9H3uWUzYFv)_