### PR TITLE
Implement WS-02: DAG-CBOR codec and data-model completion

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,10 +9,10 @@
         com.google.crypto.tink/tink {:mvn/version "1.7.0"}
         mvxcvi/multiformats {:mvn/version "1.0.125"}}
  :aliases {:dev  {:extra-paths ["test" "dev" "examples"]
-                  :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}
+                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
                   :jvm-opts ["-Datproto.runtime.cast.dev-enabled=true"]}
            :test {:extra-paths ["test"]
-                  :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}
+                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                   :main-opts ["-m" "cognitect.test-runner"]
                   :exec-fn cognitect.test-runner.api/test}}}

--- a/docs/planning/02-dag-cbor-data-model.md
+++ b/docs/planning/02-dag-cbor-data-model.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Planning |
+| **Status** | Implemented (all 4 milestones; cljs CI verification deferred to WS-10) |
 | **Priority** | P0 |
 | **Estimated size** | L |
 | **Branch** | ws/02-dag-cbor-data-model |
@@ -330,17 +330,17 @@ All tests `.cljc` under `test/`, runnable with `clojure -X:test` on the JVM (clj
 
 ## Acceptance criteria
 
-- [ ] `clojure -X:test` is green on JVM with all new tests enabled.
-- [ ] All 3 vendored data-model fixtures pass: byte-exact `encode`, CID-exact `cid-for`, JSON round-trip.
-- [ ] All ported strictness vectors behave as specified (floats, duplicate keys, indefinite lengths, non-shortest forms, bad tag-42 lead-in, trailing bytes, `f7` coercion).
-- [ ] `(data/format-cid (data/blob-ref (bytes-of "...")))` matches an independently computed raw CID (the `mhash/create` bug is fixed and pinned by a known-answer test).
-- [ ] `data.json/encode` emits unpadded `$bytes`; `base64-encode`/`base64-decode` and `bytes/eq?` have working `:cljs` branches (code-reviewed; cljs CI execution is WS-10).
-- [ ] `decode-multi` decodes a buffer of ≥2 concatenated items (firehose-frame shape) and errors on truncation.
-- [ ] `atproto.runtime.varint` round-trips and matches `multiformats.varint` byte-for-byte.
-- [ ] `::data/legacy-blob`, `legacy-blob?`, `upgrade-legacy-blob` exist and are spec'd; codecs pass legacy blobs through unchanged.
-- [ ] The TODO at `src/atproto/data.cljc:144` is replaced with the documented decision.
-- [ ] No new dependency added to `deps.edn` (or, if the library route is taken after all, the decision is recorded in this doc's Risks section and the dep is JVM+cljs compatible).
-- [ ] Manual live check against a real PDS record documented and performed once (`getRecord` CID parity).
+- [x] `clojure -X:test` is green on JVM with all new tests enabled.
+- [x] All 3 vendored data-model fixtures pass: byte-exact `encode`, CID-exact `cid-for`, JSON round-trip.
+- [x] All ported strictness vectors behave as specified (floats, duplicate keys, indefinite lengths, non-shortest forms, bad tag-42 lead-in, trailing bytes, `f7` coercion).
+- [x] `(data/format-cid (data/blob-ref (bytes-of "...")))` matches an independently computed raw CID (the `mhash/create` bug is fixed and pinned by a known-answer test).
+- [x] `data.json/encode` emits unpadded `$bytes`; `base64-encode`/`base64-decode` and `bytes/eq?` have working `:cljs` branches (code-reviewed; cljs CI execution is WS-10).
+- [x] `decode-multi` decodes a buffer of ≥2 concatenated items (firehose-frame shape) and errors on truncation.
+- [x] `atproto.runtime.varint` round-trips and matches `multiformats.varint` byte-for-byte.
+- [x] `::data/legacy-blob`, `legacy-blob?`, `upgrade-legacy-blob` exist and are spec'd; codecs pass legacy blobs through unchanged.
+- [x] The TODO at `src/atproto/data.cljc:144` is replaced with the documented decision.
+- [x] No new dependency added to `deps.edn` (or, if the library route is taken after all, the decision is recorded in this doc's Risks section and the dep is JVM+cljs compatible).
+- [x] Manual live check against a real PDS record documented and performed once (`getRecord` CID parity).
 
 ## Milestones
 

--- a/src/atproto/data.cljc
+++ b/src/atproto/data.cljc
@@ -9,8 +9,10 @@
             [multiformats.cid :as cid]
             [multiformats.hash :as mhash]
             [atproto.runtime.bytes :as bytes]
+            [atproto.data.cbor :as cbor]
             [atproto.lexicon.regex :as regex]
-            [atproto.data.blob :as-alias blob]))
+            [atproto.data.blob :as-alias blob]
+            [atproto.data.legacy-blob :as-alias legacy-blob]))
 
 ;; -----------------------------------------------------------------------------
 ;; CID: https://atproto.com/specs/data-model#link-and-cid-formats
@@ -22,13 +24,13 @@
   (cid/cid? input))
 
 (defn cid-link
-  "Create a CID to be used as a `link`.
+  "CID for already-encoded DAG-CBOR bytes. For un-encoded data, use cid-for.
 
   multicodec: `dag-cbor` (0x71)
   multihash: `sha-256` with 256 bits."
-  [bytes]
+  [cbor-bytes]
   (cid/create :ipld-cbor
-              (mhash/create :sha2-256 bytes)))
+              (mhash/sha2-256 cbor-bytes)))
 
 (defn cid-link?
   "Whether the cid is a valid CID for atproto links."
@@ -44,7 +46,7 @@
   multihash: `sha-256` with 256 bits."
   [bytes]
   (cid/create :raw
-              (mhash/create :sha2-256 bytes)))
+              (mhash/sha2-256 bytes)))
 
 (defn blob-ref?
   "Whether the cid is a valid CID to atproto blob references."
@@ -77,6 +79,39 @@
     (cid/parse s)
     (catch #?(:clj Exception
               :cljs js/Error) _)))
+
+(defn cid-for
+  "Compute the CID of atproto data: DAG-CBOR encode, sha2-256,
+  CIDv1 with the dag-cbor (0x71) multicodec.
+
+  Throws (as atproto.data.cbor/encode) if data is not valid
+  atproto data."
+  [data]
+  (cid/create :ipld-cbor (mhash/sha2-256 (cbor/encode data))))
+
+(defn verify-cid
+  "Verify that cid matches the given bytes.
+
+  Hashes bytes with the cid's multihash algorithm (sha2-256 or
+  sha2-512) and compares digests.
+
+  Returns true on match, otherwise an error map:
+  {:error \"CidMismatch\" :message <...> :expected <cid-str> :actual <cid-str>}
+  {:error \"UnsupportedHashAlgorithm\" :message <...>}"
+  [cid bytes]
+  (let [alg (:algorithm (:hash cid))]
+    (if-let [hash-fn (case alg
+                       :sha2-256 mhash/sha2-256
+                       :sha2-512 mhash/sha2-512
+                       nil)]
+      (let [computed (hash-fn bytes)]
+        (or (= computed (:hash cid))
+            {:error "CidMismatch"
+             :message "CID does not match the bytes."
+             :expected (cid/format cid)
+             :actual (cid/format (cid/create (:codec cid) computed))}))
+      {:error "UnsupportedHashAlgorithm"
+       :message (str "Unsupported CID multihash algorithm: " (pr-str alg))})))
 
 ;; -----------------------------------------------------------------------------
 ;; Validation
@@ -138,10 +173,53 @@
          :object  ::object)))
 
 ;; -----------------------------------------------------------------------------
+;; Legacy untyped blob refs
+;;
+;; Older atproto records reference blobs as {:cid <cid-string> :mimeType <str>}
+;; instead of the typed form. The JSON and CBOR codecs deliberately pass these
+;; through as plain maps (TS parity); validation/upgrade is the application's
+;; (or the lexicon lenient mode's) concern.
+;; -----------------------------------------------------------------------------
+
+(s/def ::legacy-blob/cid
+  (s/and string? parse-cid))
+
+(s/def ::legacy-blob/mimeType
+  (s/and string? seq))
+
+(s/def ::legacy-blob
+  (s/and (s/keys :req-un [::legacy-blob/cid
+                          ::legacy-blob/mimeType])
+         #(= #{:cid :mimeType} (set (keys %)))))
+
+(defn legacy-blob?
+  "Whether the value is a legacy untyped blob ref."
+  [v]
+  (s/valid? ::legacy-blob v))
+
+(defn upgrade-legacy-blob
+  "Convert a legacy untyped blob ref to the typed form.
+
+  Returns {:$type \"blob\" :ref <parsed CID> :mimeType <mimeType> :size -1},
+  or nil if input is not a valid legacy blob ref."
+  [m]
+  (when (legacy-blob? m)
+    {:$type "blob"
+     :ref (parse-cid (:cid m))
+     :mimeType (:mimeType m)
+     :size -1}))
+
+;; -----------------------------------------------------------------------------
 ;; Equality
 ;; -----------------------------------------------------------------------------
 
-;; todo: consider introducing an immutables bytes type to not have to do that
+;; Decision (WS-02): the data model keeps raw platform byte arrays as its
+;; bytes representation — no immutable wrapper type. A wrapper would ripple
+;; through every spec, codec, and platform boundary (hashing, HTTP bodies,
+;; websockets), and the TS SDK uses raw Uint8Array the same way. The cost is
+;; that platform arrays use identity equality, so values containing bytes
+;; don't compare with `=`; this `eq?` is the structural-equality entry point
+;; for atproto data values.
 (defn eq?
   [a b]
   (or (= a b)

--- a/src/atproto/data/cbor.cljc
+++ b/src/atproto/data/cbor.cljc
@@ -1,0 +1,464 @@
+(ns atproto.data.cbor
+  "DAG-CBOR codec for the atproto data model subset.
+
+  Canonical form: definite lengths only, shortest-form integers,
+  map keys sorted length-first then bytewise; CID links as tag 42
+  with 0x00 identity-multibase prefix; no floats.
+
+  Invalid input throws ex-info whose ex-data is an SDK-style error map
+  ({:error \"InvalidDataModel\"} on encode, {:error \"InvalidCbor\"} on
+  decode). Errors are thrown rather than returned because decoded data
+  is arbitrary and {:error ...} is itself a valid atproto data value.
+
+  Note: decode does not enforce sorted map keys (matching the TS
+  reference), so decode->encode of non-canonical third-party bytes may
+  not be byte-identical. Verification code must always hash the
+  original bytes, never re-encoded ones.
+
+  See https://atproto.com/specs/data-model and
+  https://ipld.io/specs/codecs/dag-cbor/spec/"
+  (:require [multiformats.cid :as cid]
+            [atproto.runtime.bytes :as bytes]
+            #?@(:cljs [[goog.crypt]]))
+  #?(:clj (:import [java.io ByteArrayOutputStream]
+                   [java.util Arrays]
+                   [java.nio.charset StandardCharsets])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; Integers must stay within the JS safe range: ±(2^53 - 1).
+(def ^:private max-safe-int 9007199254740991)
+
+(def ^:private cid-cbor-tag 42)
+
+;; -----------------------------------------------------------------------------
+;; Errors
+;; -----------------------------------------------------------------------------
+
+(defn- encode-error!
+  [message path]
+  (throw (ex-info message {:error "InvalidDataModel"
+                           :message message
+                           :path path})))
+
+(defn- decode-error!
+  [message offset]
+  (throw (ex-info message {:error "InvalidCbor"
+                           :message message
+                           :offset offset})))
+
+;; -----------------------------------------------------------------------------
+;; Byte helpers
+;; -----------------------------------------------------------------------------
+
+(defn- blength
+  [b]
+  #?(:clj (alength ^bytes b)
+     :cljs (.-length b)))
+
+(defn- ubyte
+  "Unsigned byte at index i."
+  [b i]
+  (bit-and #?(:clj (aget ^bytes b (int i))
+              :cljs (aget b i))
+           0xff))
+
+(defn- bslice
+  [b start end]
+  #?(:clj (Arrays/copyOfRange ^bytes b (int start) (int end))
+     :cljs (.slice b start end)))
+
+(defn- utf8-bytes
+  [s]
+  #?(:clj (.getBytes ^String s StandardCharsets/UTF_8)
+     :cljs (goog.crypt/stringToUtf8ByteArray s)))
+
+;; -----------------------------------------------------------------------------
+;; Encoder
+;; -----------------------------------------------------------------------------
+
+(defn- new-writer
+  []
+  #?(:clj (ByteArrayOutputStream.)
+     :cljs #js []))
+
+(defn- write-byte!
+  [w b]
+  #?(:clj (.write ^ByteArrayOutputStream w (unchecked-int b))
+     :cljs (.push w (bit-and b 0xff))))
+
+(defn- write-bytes!
+  [w bs]
+  #?(:clj (.write ^ByteArrayOutputStream w ^bytes bs 0 (alength ^bytes bs))
+     :cljs (dotimes [i (.-length bs)]
+             (.push w (bit-and (aget bs i) 0xff)))))
+
+(defn- writer->bytes
+  [w]
+  #?(:clj (.toByteArray ^ByteArrayOutputStream w)
+     :cljs (js/Int8Array.from w)))
+
+(defn- write-u16!
+  [w n]
+  (write-byte! w (bit-and (unsigned-bit-shift-right n 8) 0xff))
+  (write-byte! w (bit-and n 0xff)))
+
+(defn- write-u32!
+  [w n]
+  (write-byte! w (bit-and (unsigned-bit-shift-right n 24) 0xff))
+  (write-byte! w (bit-and (unsigned-bit-shift-right n 16) 0xff))
+  (write-byte! w (bit-and (unsigned-bit-shift-right n 8) 0xff))
+  (write-byte! w (bit-and n 0xff)))
+
+(defn- write-head!
+  "Write an item head: major type + shortest-form argument."
+  [w major n]
+  (let [mt (bit-shift-left major 5)]
+    (cond
+      (< n 24)
+      (write-byte! w (bit-or mt n))
+
+      (< n 0x100)
+      (do (write-byte! w (bit-or mt 24))
+          (write-byte! w n))
+
+      (< n 0x10000)
+      (do (write-byte! w (bit-or mt 25))
+          (write-u16! w n))
+
+      (< n 0x100000000)
+      (do (write-byte! w (bit-or mt 26))
+          (write-u32! w n))
+
+      :else
+      (do (write-byte! w (bit-or mt 27))
+          ;; quot/rem instead of 64-bit shifts so this works on cljs doubles
+          (write-u32! w (quot n 0x100000000))
+          (write-u32! w (rem n 0x100000000))))))
+
+(defn- compare-key-bytes
+  "DAG-CBOR canonical map key order: byte length first, then bytewise
+  (unsigned) comparison."
+  [a b]
+  (let [la (blength a)
+        lb (blength b)]
+    (if (not= la lb)
+      (compare la lb)
+      (loop [i 0]
+        (if (= i la)
+          0
+          (let [ba (ubyte a i)
+                bb (ubyte b i)]
+            (if (= ba bb)
+              (recur (inc i))
+              (compare ba bb))))))))
+
+(declare encode-value!)
+
+(defn- encode-int!
+  [w n path]
+  (when-not (<= (- max-safe-int) n max-safe-int)
+    (encode-error! (str "Integer out of range, must be within ±(2^53 - 1): " n) path))
+  (if (neg? n)
+    (write-head! w 1 (- -1 n))
+    (write-head! w 0 n)))
+
+(defn- encode-string!
+  [w s]
+  (let [b (utf8-bytes s)]
+    (write-head! w 3 (blength b))
+    (write-bytes! w b)))
+
+(defn- encode-cid!
+  [w c]
+  (let [cb (cid/encode c)]
+    (write-head! w 6 cid-cbor-tag)
+    ;; 0x00 identity-multibase prefix, for historical reasons
+    (write-head! w 2 (inc (blength cb)))
+    (write-byte! w 0x00)
+    (write-bytes! w cb)))
+
+(defn- map-key->string
+  [k path]
+  (cond
+    (string? k) k
+    (and (keyword? k) (nil? (namespace k))) (name k)
+    :else (encode-error! (str "Map keys must be strings or unqualified keywords: " (pr-str k))
+                         path)))
+
+(defn- encode-map!
+  [w m path]
+  (let [entries (mapv (fn [[k v]]
+                        (let [ks (map-key->string k path)]
+                          [(utf8-bytes ks) ks k v]))
+                      m)]
+    (when (not= (count entries)
+                (count (into #{} (map second) entries)))
+      (encode-error! "Duplicate map keys after string conversion" path))
+    (write-head! w 5 (count entries))
+    (doseq [[kb _ k v] (sort-by first compare-key-bytes entries)]
+      (write-head! w 3 (blength kb))
+      (write-bytes! w kb)
+      (encode-value! w v (conj path k)))))
+
+(defn- encode-array!
+  [w v path]
+  (write-head! w 4 (count v))
+  (loop [i 0
+         items (seq v)]
+    (when items
+      (encode-value! w (first items) (conj path i))
+      (recur (inc i) (next items)))))
+
+(defn- encode-value!
+  [w v path]
+  (cond
+    (nil? v)         (write-byte! w 0xf6)
+    (true? v)        (write-byte! w 0xf5)
+    (false? v)       (write-byte! w 0xf4)
+    (int? v)         (encode-int! w v path)
+    (string? v)      (encode-string! w v)
+    (bytes/bytes? v) (do (write-head! w 2 (blength v))
+                         (write-bytes! w v))
+    (cid/cid? v)     (encode-cid! w v)
+    (map? v)         (encode-map! w v path)
+    (sequential? v)  (encode-array! w v path)
+    (number? v)      (encode-error! (str "Non-integer numbers are not supported: " v) path)
+    :else            (encode-error! (str "Unsupported value type: " (pr-str (type v))) path)))
+
+(defn encode
+  "Encode atproto data to canonical DAG-CBOR bytes.
+
+  Accepts: nil, booleans, integers in [-(2^53 - 1), 2^53 - 1], strings,
+  platform bytes, CIDs (multiformats.cid), vectors/sequentials, and
+  maps with unqualified-keyword (or string) keys.
+
+  Returns platform bytes (clj: byte[]).
+  Throws ex-info with ex-data {:error \"InvalidDataModel\"
+                               :message <human-readable>
+                               :path <vector path into data>}
+  on floats, out-of-range ints, qualified/non-string keys, or any
+  unsupported value type."
+  #?(:clj ^bytes [data] :cljs [data])
+  (let [w (new-writer)]
+    (encode-value! w data [])
+    (writer->bytes w)))
+
+;; -----------------------------------------------------------------------------
+;; Decoder
+;; -----------------------------------------------------------------------------
+
+(defn- check-len!
+  "Ensure `need` bytes are available starting at `off`."
+  [b off need]
+  (when (> (+ off need) (blength b))
+    (decode-error! "Unexpected end of input" off)))
+
+(defn- read-arg
+  "Read the argument of an item head (additional info `info` at offset
+  `off`, head byte already consumed). Returns [arg new-off]. Enforces
+  shortest-form encoding and platform integer range."
+  [b off info]
+  (cond
+    (< info 24)
+    [info off]
+
+    (= info 24)
+    (do (check-len! b off 1)
+        (let [v (ubyte b off)]
+          (when (< v 24)
+            (decode-error! "Non-shortest-form argument encoding" (dec off)))
+          [v (inc off)]))
+
+    (= info 25)
+    (do (check-len! b off 2)
+        (let [v (+ (* (ubyte b off) 0x100)
+                   (ubyte b (inc off)))]
+          (when (< v 0x100)
+            (decode-error! "Non-shortest-form argument encoding" (dec off)))
+          [v (+ off 2)]))
+
+    (= info 26)
+    (do (check-len! b off 4)
+        (let [v (+ (* (ubyte b off) 0x1000000)
+                   (* (ubyte b (inc off)) 0x10000)
+                   (* (ubyte b (+ off 2)) 0x100)
+                   (ubyte b (+ off 3)))]
+          (when (< v 0x10000)
+            (decode-error! "Non-shortest-form argument encoding" (dec off)))
+          [v (+ off 4)]))
+
+    (= info 27)
+    (do (check-len! b off 8)
+        (let [hi (+ (* (ubyte b off) 0x1000000)
+                    (* (ubyte b (inc off)) 0x10000)
+                    (* (ubyte b (+ off 2)) 0x100)
+                    (ubyte b (+ off 3)))
+              lo (+ (* (ubyte b (+ off 4)) 0x1000000)
+                    (* (ubyte b (+ off 5)) 0x10000)
+                    (* (ubyte b (+ off 6)) 0x100)
+                    (ubyte b (+ off 7)))]
+          #?(:clj (when (<= 0x80000000 hi)
+                    ;; would exceed the signed 64-bit range
+                    (decode-error! "Integer out of range" (dec off)))
+             :cljs (when (<= 0x200000 hi)
+                     ;; would exceed the JS safe-integer range
+                     (decode-error! "Integer out of range" (dec off))))
+          (let [v (+ (* hi 0x100000000) lo)]
+            #?(:cljs (when (> v max-safe-int)
+                       (decode-error! "Integer out of range" (dec off))))
+            (when (< v 0x100000000)
+              (decode-error! "Non-shortest-form argument encoding" (dec off)))
+            [v (+ off 8)])))
+
+    (= info 31)
+    (decode-error! "Indefinite lengths are not supported" (dec off))
+
+    :else
+    (decode-error! (str "Reserved additional info: " info) (dec off))))
+
+(declare decode-at)
+
+(defn- read-byte-string
+  [b off len]
+  (check-len! b off len)
+  [(bslice b off (+ off len)) (+ off len)])
+
+(defn- read-text
+  [b off len]
+  (check-len! b off len)
+  [#?(:clj (String. ^bytes b (int off) (int len) StandardCharsets/UTF_8)
+      :cljs (bytes/->utf8 (.slice b off (+ off len))))
+   (+ off len)])
+
+(defn- read-array
+  [b off n]
+  (loop [i 0
+         off off
+         acc (transient [])]
+    (if (= i n)
+      [(persistent! acc) off]
+      (let [[v off'] (decode-at b off)]
+        (recur (inc i) off' (conj! acc v))))))
+
+(defn- read-map-key
+  "Map keys must be text strings. Returns [string new-off]."
+  [b off]
+  (check-len! b off 1)
+  (let [ib (ubyte b off)
+        major (bit-shift-right ib 5)
+        info (bit-and ib 0x1f)]
+    (when (not= 3 major)
+      (decode-error! "Map keys must be strings" off))
+    (let [[len off'] (read-arg b (inc off) info)]
+      (read-text b off' len))))
+
+(defn- read-map
+  [b off n]
+  (loop [i 0
+         off off
+         acc (transient {})]
+    (if (= i n)
+      [(persistent! acc) off]
+      (let [key-off off
+            [ks off'] (read-map-key b off)
+            k (keyword ks)]
+        (when (contains? acc k)
+          (decode-error! (str "Duplicate map key: " (pr-str ks)) key-off))
+        (let [[v off''] (decode-at b off')]
+          (recur (inc i) off'' (assoc! acc k v)))))))
+
+(defn- read-tag
+  [b off tag]
+  (when (not= cid-cbor-tag tag)
+    (decode-error! (str "Unsupported CBOR tag: " tag) off))
+  (check-len! b off 1)
+  (let [ib (ubyte b off)
+        major (bit-shift-right ib 5)
+        info (bit-and ib 0x1f)]
+    (when (not= 2 major)
+      (decode-error! "CBOR tag 42 must contain a byte string" off))
+    (let [[len off'] (read-arg b (inc off) info)
+          [payload off''] (read-byte-string b off' len)]
+      (when (or (zero? len)
+                (not (zero? (ubyte payload 0))))
+        (decode-error! "Invalid CID for CBOR tag 42; expected leading 0x00" off))
+      (let [cid (try
+                  (cid/decode (bslice payload 1 len))
+                  (catch #?(:clj Exception :cljs js/Error) e
+                    (decode-error! (str "Invalid CID in CBOR tag 42: "
+                                        #?(:clj (.getMessage e)
+                                           :cljs (.-message e)))
+                                   off)))]
+        [cid off'']))))
+
+(defn- read-simple
+  "Major type 7: simple values and floats."
+  [b off info]
+  (case (long info)
+    20 [false (inc off)]
+    21 [true (inc off)]
+    22 [nil (inc off)]
+    23 [nil (inc off)] ;; undefined (0xf7) is coerced to null
+    (25 26 27) (decode-error! "Floats are not supported" off)
+    31 (decode-error! "Unexpected break code" off)
+    (decode-error! (str "Unsupported simple value: " info) off)))
+
+(defn- decode-at
+  "Decode the item starting at `off`. Returns [value new-off]."
+  [b off]
+  (check-len! b off 1)
+  (let [ib (ubyte b off)
+        major (bit-shift-right ib 5)
+        info (bit-and ib 0x1f)]
+    (if (= 7 major)
+      (read-simple b off info)
+      (let [[arg off'] (read-arg b (inc off) info)]
+        (case major
+          0 [arg off']
+          1 [(- -1 arg) off']
+          2 (read-byte-string b off' arg)
+          3 (read-text b off' arg)
+          4 (read-array b off' arg)
+          5 (read-map b off' arg)
+          6 (read-tag b off' arg))))))
+
+(defn decode
+  "Decode a single DAG-CBOR item; rejects trailing bytes.
+
+  Map keys become unqualified keywords; tag 42 becomes a CID;
+  byte strings become platform bytes; 0xf7 (undefined) becomes nil.
+
+  Throws ex-info with ex-data {:error \"InvalidCbor\"
+                               :message <...> :offset <byte offset>}
+  on floats, indefinite lengths, non-shortest-form encodings,
+  duplicate map keys, unknown tags/simple values, bad tag-42 payloads
+  (missing 0x00 prefix or invalid CID), truncation, or trailing bytes."
+  [bytes]
+  (let [[v off] (decode-at bytes 0)]
+    (when (< off (blength bytes))
+      (decode-error! "Unexpected trailing bytes after decoded item" off))
+    v))
+
+(defn decode-first
+  "Decode the first DAG-CBOR item in bytes.
+
+  Returns [value bytes-consumed]. Same strictness/errors as decode,
+  except trailing bytes are expected and left for the caller."
+  [bytes]
+  (decode-at bytes 0))
+
+(defn decode-multi
+  "Decode a buffer of concatenated DAG-CBOR items (e.g. a firehose
+  frame: header item followed by body item).
+
+  Returns a vector of decoded values. Throws (as decode) if any item
+  is invalid or the final item is truncated."
+  [bytes]
+  (loop [off 0
+         acc []]
+    (let [[v off'] (decode-at bytes off)
+          acc (conj acc v)]
+      (if (< off' (blength bytes))
+        (recur (long off') acc)
+        acc))))

--- a/src/atproto/data/json.cljc
+++ b/src/atproto/data/json.cljc
@@ -59,7 +59,11 @@
 ;; -----------------------------------------------------------------------------
 
 (defn encode
-  "Take valid atproto data and return the JSON value."
+  "Take valid atproto data and return the JSON value.
+
+  Bytes are emitted as {:$bytes <unpadded standard base64>}. Legacy
+  untyped blob refs are not special-cased: they pass through as plain
+  maps (TS parity); see atproto.data/legacy-blob?."
   [data]
   (cond
     (nil? data)        data
@@ -72,7 +76,10 @@
     (map? data)        (into {} (map (fn [[k v]] [k (encode v)]) data))))
 
 (defn decode
-  "Take a valid JSON value and return the atproto data."
+  "Take a valid JSON value and return the atproto data.
+
+  Legacy untyped blob refs are not special-cased: they pass through as
+  plain maps (TS parity); see atproto.data/legacy-blob?."
   [value]
   (cond
     (nil? value)        value

--- a/src/atproto/runtime/bytes.cljc
+++ b/src/atproto/runtime/bytes.cljc
@@ -14,7 +14,13 @@
 
 (defn eq?
   [a b]
-  #?(:clj (Arrays/equals ^bytes a ^bytes b)))
+  #?(:clj (Arrays/equals ^bytes a ^bytes b)
+     :cljs (and (= (.-length a) (.-length b))
+                (loop [i 0]
+                  (cond
+                    (= i (.-length a)) true
+                    (= (aget a i) (aget b i)) (recur (inc i))
+                    :else false)))))
 
 (defn ->utf8
   [bytes]

--- a/src/atproto/runtime/crypto.cljc
+++ b/src/atproto/runtime/crypto.cljc
@@ -1,6 +1,7 @@
 (ns atproto.runtime.crypto
   "Cross-platform cryptographic functions for atproto."
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            #?@(:cljs [[goog.crypt.base64 :as b64]]))
   #?(:clj (:import [java.util Base64]
                    [com.nimbusds.jose.util Base64URL]
                    [java.security SecureRandom MessageDigest]
@@ -27,12 +28,27 @@
                    (.getBytes ^String s StandardCharsets/UTF_8))))
 
 (defn base64-encode
-  [s]
-  #?(:clj (try (.encodeToString (Base64/getEncoder) ^String s) (catch Exception _))))
+  "bytes -> standard-alphabet base64 string, no padding (atproto `$bytes` form)."
+  [b]
+  #?(:clj (.encodeToString (.withoutPadding (Base64/getEncoder)) ^bytes b)
+     :cljs (b64/encodeByteArray
+            (js/Uint8Array. (.-buffer b) (.-byteOffset b) (.-length b))
+            (.-NO_PADDING b64/Alphabet))))
 
 (defn base64-decode
+  "Standard-alphabet base64 string (padded or unpadded) -> bytes.
+
+  Returns nil if the input is not valid base64."
   [s]
-  #?(:clj (try (.decode (Base64/getDecoder) ^String s) (catch Exception _))))
+  (when (string? s)
+    (let [stripped (str/replace s #"=+$" "")]
+      (when (and (re-matches #"[A-Za-z0-9+/]*" stripped)
+                 (not= 1 (mod (count stripped) 4)))
+        #?(:clj (try
+                  (.decode (Base64/getDecoder) ^String stripped)
+                  (catch Exception _ nil))
+           :cljs (let [u8 (b64/decodeStringToUint8Array stripped)]
+                   (js/Int8Array. (.-buffer u8) (.-byteOffset u8) (.-length u8))))))))
 
 (defn base64url-encode
   "bytes -> url-safe base64 string."

--- a/src/atproto/runtime/varint.cljc
+++ b/src/atproto/runtime/varint.cljc
@@ -1,0 +1,23 @@
+(ns atproto.runtime.varint
+  "Unsigned LEB128 varints (multiformats unsigned-varint).
+
+  Used for CAR block framing and CID prefixes. Thin wrapper over
+  multiformats.varint so consumers don't bind to the library directly."
+  (:require [multiformats.varint :as varint]))
+
+(defn encode
+  "n -> bytes"
+  #?(:clj ^bytes [n] :cljs [n])
+  (varint/encode n))
+
+(defn decode
+  "bytes -> n (reads from offset 0, ignores trailing bytes)"
+  [bytes]
+  (varint/decode bytes))
+
+(defn read-bytes
+  "Read a varint at offset. Returns [value bytes-read].
+
+  Throws ex-info on truncation or >9-byte varints."
+  [bytes offset]
+  (varint/read-bytes bytes offset))

--- a/test/atproto/data/cbor_test.cljc
+++ b/test/atproto/data/cbor_test.cljc
@@ -1,0 +1,385 @@
+(ns atproto.data.cbor-test
+  "Tests for the DAG-CBOR codec.
+
+  Live verification (manual, not CI): fetch any public record and check
+  CID parity against the PDS, e.g.
+
+      GET https://bsky.social/xrpc/com.atproto.repo.getRecord?repo=<did>
+            &collection=app.bsky.feed.post&rkey=<rkey>
+
+  then check (= cid (data/format-cid (data/cid-for (json/decode value)))).
+  Last performed 2026-06-11 against
+  at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mnslrkd6ok2g
+  (cid bafyreigh4yjzzjiwjrlm4xe5yiu456ncqc6tfnf5ctup2sii7knhdineru): parity true."
+  (:require #?@(:clj [[clojure.test :refer :all]
+                      [clojure.java.io :as io]]
+                :cljs [[cljs.test :refer :all]])
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.crypto :as crypto]
+            #?(:clj [atproto.runtime.json :as runtime.json])
+            [atproto.data :as data]
+            [atproto.data.json :as json]
+            [atproto.data.cbor :as cbor])
+  #?(:cljs (:require-macros [atproto.data.cbor-test :refer [data-model-fixtures]])))
+
+;; -----------------------------------------------------------------------------
+;; Helpers
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (defmacro data-model-fixtures
+     "Inline the vendored data-model interop fixtures.
+
+      Each fixture is {:json <value> :cbor_base64 <str> :cid <str>}.
+      Source: bluesky-social/atproto packages/lex/lex-cbor/tests/data-model-fixtures.json"
+     []
+     (runtime.json/read-str
+      (slurp (io/resource "interop-test-files/data-model/data-model-fixtures.json")))))
+
+(defn hex->bytes
+  [s]
+  (let [ints (map (fn [[a b]]
+                    #?(:clj (Integer/parseInt (str a b) 16)
+                       :cljs (js/parseInt (str a b) 16)))
+                  (partition 2 s))]
+    #?(:clj (byte-array (map unchecked-byte ints))
+       :cljs (js/Int8Array.from (into-array ints)))))
+
+(defn bytes->hex
+  [b]
+  (let [n #?(:clj (alength ^bytes b) :cljs (.-length b))]
+    (apply str
+           (map (fn [i]
+                  (let [x (bit-and #?(:clj (aget ^bytes b i) :cljs (aget b i)) 0xff)]
+                    #?(:clj (format "%02x" x)
+                       :cljs (.padStart (.toString x 16) 2 "0"))))
+                (range n)))))
+
+(defn concat-bytes
+  [a b]
+  #?(:clj (byte-array (concat (seq a) (seq b)))
+     :cljs (js/Int8Array.from (concat (array-seq a) (array-seq b)))))
+
+(defn- invalid-cbor?
+  "Whether decoding the hex throws an InvalidCbor error."
+  [decode-fn hex]
+  (try
+    (decode-fn (hex->bytes hex))
+    false
+    (catch #?(:clj Exception :cljs js/Error) e
+      (= "InvalidCbor" (:error (ex-data e))))))
+
+(defn- invalid-data-model?
+  "Whether encoding the value throws an InvalidDataModel error."
+  [v]
+  (try
+    (cbor/encode v)
+    false
+    (catch #?(:clj Exception :cljs js/Error) e
+      (= "InvalidDataModel" (:error (ex-data e))))))
+
+;; -----------------------------------------------------------------------------
+;; Vendored interop fixtures
+;; -----------------------------------------------------------------------------
+
+(deftest test-interop-fixtures
+  (doseq [{:keys [json cbor_base64 cid]} (data-model-fixtures)]
+    (let [value (json/decode json)
+          cbor-bytes (crypto/base64-decode cbor_base64)]
+      (testing "encode is byte-exact"
+        (is (= (bytes->hex cbor-bytes)
+               (bytes->hex (cbor/encode value)))))
+      (testing "cid-for matches the fixture CID"
+        (is (= cid (data/format-cid (data/cid-for value)))))
+      (testing "cid-link of the encoded bytes matches the fixture CID"
+        (is (= cid (data/format-cid (data/cid-link cbor-bytes)))))
+      (testing "decode-multi yields exactly one value that round-trips to JSON"
+        (let [decoded (cbor/decode-multi cbor-bytes)]
+          (is (= 1 (count decoded)))
+          (is (= json (json/encode (first decoded))))))
+      (testing "verify-cid against the original bytes"
+        (is (true? (data/verify-cid (data/parse-cid cid) cbor-bytes)))))))
+
+;; -----------------------------------------------------------------------------
+;; Canonical form
+;; -----------------------------------------------------------------------------
+
+(deftest test-canonical-encoding
+  (testing "simple map"
+    (is (= "a16568656c6c6f65776f726c64"
+           (bytes->hex (cbor/encode {:hello "world"})))))
+
+  (testing "scalars"
+    (are [hex v] (= hex (bytes->hex (cbor/encode v)))
+      "f6" nil
+      "f5" true
+      "f4" false
+      "60" ""
+      "6161" "a"
+      "40" #?(:clj (byte-array 0) :cljs (js/Int8Array. 0))
+      "80" []
+      "a0" {}))
+
+  (testing "shortest-form integer heads across boundaries"
+    (are [hex n] (= hex (bytes->hex (cbor/encode n)))
+      "00" 0
+      "17" 23
+      "1818" 24
+      "18ff" 255
+      "190100" 256
+      "19ffff" 65535
+      "1a00010000" 65536
+      "1affffffff" 4294967295
+      "1b0000000100000000" 4294967296
+      "1b001fffffffffffff" 9007199254740991
+      "20" -1
+      "37" -24
+      "3818" -25
+      "38ff" -256
+      "390100" -257
+      "3b001ffffffffffffe" -9007199254740991))
+
+  (testing "map keys sorted by length first, then bytewise"
+    ;; "b" and "c" (1 byte) sort before "aa" (2 bytes)
+    (is (= "a361620161630362616102"
+           (bytes->hex (cbor/encode {:aa 2 :b 1 :c 3}))))
+    ;; multi-byte UTF-8 key: "zz" (7a7a) sorts before "é" (c3a9)
+    (is (= "a2627a7a0262c3a901"
+           (bytes->hex (cbor/encode {:é 1 :zz 2})))))
+
+  (testing "string keys and keyword keys encode identically"
+    (is (= (bytes->hex (cbor/encode {:hello "world"}))
+           (bytes->hex (cbor/encode {"hello" "world"})))))
+
+  (testing "tag 42 byte pattern appears once per link"
+    (let [cid (data/parse-cid "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a")
+          hex (bytes->hex (cbor/encode {:link cid :links [cid cid]}))]
+      (is (= 3 (count (re-seq #"d82a582500" hex)))))))
+
+;; -----------------------------------------------------------------------------
+;; Encode rejections
+;; -----------------------------------------------------------------------------
+
+(deftest test-encode-rejections
+  (testing "floats, NaN, Infinity"
+    (are [v] (invalid-data-model? v)
+      3.14
+      {:value 3.14}
+      ##NaN
+      ##Inf
+      ##-Inf
+      [1 -1 9007199254740991 ##NaN -9007199254740991]))
+
+  (testing "integers out of the ±(2^53 - 1) range"
+    (are [v] (invalid-data-model? v)
+      9007199254740992
+      -9007199254740992)
+    (is (some? (cbor/encode 9007199254740991)))
+    (is (some? (cbor/encode -9007199254740991))))
+
+  (testing "invalid map keys"
+    (are [v] (invalid-data-model? v)
+      {:a/b 1}
+      {1 2}
+      {:a 1 "a" 2}))
+
+  (testing "unsupported value types"
+    (are [v] (invalid-data-model? v)
+      :keyword-value
+      #{1 2}
+      'sym
+      #?(:clj 1N)
+      #?(:clj (java.util.Date.) :cljs (js/Date.))))
+
+  (testing "ex-data carries the path into the data"
+    (let [ex-data' (try
+                     (cbor/encode {:a [{:b 3.14}]})
+                     nil
+                     (catch #?(:clj Exception :cljs js/Error) e
+                       (ex-data e)))]
+      (is (= "InvalidDataModel" (:error ex-data')))
+      (is (= [:a 0 :b] (:path ex-data'))))))
+
+;; -----------------------------------------------------------------------------
+;; Decode strictness (vectors ported from lex-cbor's dag-cbor.test.ts)
+;; -----------------------------------------------------------------------------
+
+(deftest test-decode-rejections
+  (testing "floats (incl. NaN and ±Infinity forms)"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      "f97e00"
+      "f97ff8"
+      "fa7ff80000"
+      "fb7ff8000000000000"
+      "a2616161616162fb7ff8000000000000"
+      "f97c00"
+      "fb7ff0000000000000"
+      "a2616161616162fb7ff0000000000000"
+      "f9fc00"
+      "fbfff0000000000000"
+      "a2616161616162fbfff0000000000000"
+      ;; ordinary floats are rejected too (stricter than TS, per the
+      ;; atproto data-model spec)
+      "f93e00"
+      "fa40490fdb"
+      "fb40091eb851eb851f"))
+
+  (testing "duplicate map keys"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      "a3636261720363666f6f0163666f6f02"))
+
+  (testing "bad CID lead-in byte (expected 0x00)"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      "a1646c696e6bd82a582501017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5"))
+
+  (testing "unsupported tags and simple values"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      "c100"   ;; tag 1
+      "d82a00" ;; tag 42 wrapping a non-byte-string
+      "d82a40" ;; tag 42 wrapping an empty byte string
+      "f0"     ;; simple value 16
+      "f818"   ;; simple value 24
+      "ff"))   ;; break code outside indefinite item
+
+  (testing "indefinite lengths"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      "5fff"
+      "7fff"
+      "9fff"
+      "9f0102ff"
+      "bfff"))
+
+  (testing "non-shortest-form encodings"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      "1817"               ;; 23 in one extra byte
+      "1900ff"             ;; 255 in two bytes
+      "1a0000ffff"         ;; 65535 in four bytes
+      "1b00000000ffffffff" ;; 2^32-1 in eight bytes
+      "5803010203"))       ;; byte-string length 3 in long form
+
+  (testing "truncated input"
+    (are [hex] (invalid-cbor? cbor/decode hex)
+      ""
+      "18"
+      "a1"
+      "5820ff"
+      "61"
+      "8101a1"))
+
+  (testing "trailing bytes after a single decode"
+    (is (invalid-cbor? cbor/decode "0000"))
+    (is (= 0 (cbor/decode (hex->bytes "00")))))
+
+  (testing "integers outside the platform range"
+    #?(:clj (do (is (= 9223372036854775807 (cbor/decode (hex->bytes "1b7fffffffffffffff"))))
+                (is (= -9223372036854775808 (cbor/decode (hex->bytes "3b7fffffffffffffff"))))
+                (is (invalid-cbor? cbor/decode "1b8000000000000000"))
+                (is (invalid-cbor? cbor/decode "1bffffffffffffffff"))
+                (is (invalid-cbor? cbor/decode "3b8000000000000000")))
+       :cljs (do (is (= 9007199254740991 (cbor/decode (hex->bytes "1b001fffffffffffff"))))
+                 (is (invalid-cbor? cbor/decode "1b0020000000000000"))))))
+
+(deftest test-decode-coercions
+  (testing "0xf7 (undefined) is coerced to nil"
+    (is (nil? (cbor/decode (hex->bytes "f7"))))
+    (is (= {:foo "bar" :baz nil}
+           (cbor/decode (hex->bytes "a26362617af763666f6f63626172"))))))
+
+(deftest test-decode-values
+  (testing "simple map"
+    (is (= {:hello "world"}
+           (cbor/decode (hex->bytes "a16568656c6c6f65776f726c64")))))
+
+  (testing "tag 42 decodes to a CID"
+    (let [cid (data/parse-cid "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a")
+          decoded (cbor/decode (cbor/encode {:link cid}))]
+      (is (data/cid? (:link decoded)))
+      (is (= cid (:link decoded)))))
+
+  (testing "decode does not enforce sorted map keys"
+    ;; {"aa" 2, "b" 1} in non-canonical key order
+    (is (= {:aa 2 :b 1}
+           (cbor/decode (hex->bytes "a262616102616201"))))))
+
+;; -----------------------------------------------------------------------------
+;; decode-first / decode-multi
+;; -----------------------------------------------------------------------------
+
+(deftest test-decode-first-and-multi
+  (let [one {:a 123
+             :b (data/parse-cid "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a")}
+        two {:c (hex->bytes "010203")
+             :d "hello"}
+        b1 (cbor/encode one)
+        b2 (cbor/encode two)
+        both (concat-bytes b1 b2)]
+
+    (testing "decode-first returns the first value and bytes consumed"
+      (let [[v consumed] (cbor/decode-first both)]
+        (is (data/eq? one v))
+        (is (= #?(:clj (alength ^bytes b1) :cljs (.-length b1)) consumed))))
+
+    (testing "decode-multi decodes concatenated items in order"
+      (let [[v1 v2 :as vs] (cbor/decode-multi both)]
+        (is (= 2 (count vs)))
+        (is (data/eq? one v1))
+        (is (data/eq? two v2))))
+
+    (testing "decode rejects the concatenation"
+      (is (thrown? #?(:clj Exception :cljs js/Error) (cbor/decode both))))
+
+    (testing "truncated second item throws"
+      (let [truncated (concat-bytes
+                       b1
+                       #?(:clj (byte-array (butlast (seq b2)))
+                          :cljs (.slice b2 0 (dec (.-length b2)))))]
+        (is (thrown? #?(:clj Exception :cljs js/Error)
+                     (cbor/decode-multi truncated)))))
+
+    (testing "decode-multi of empty input throws"
+      (is (thrown? #?(:clj Exception :cljs js/Error)
+                   (cbor/decode-multi (hex->bytes "")))))))
+
+;; -----------------------------------------------------------------------------
+;; Generative round-trip
+;; -----------------------------------------------------------------------------
+
+(def gen-bytes
+  (gen/fmap #(#?(:clj byte-array :cljs js/Int8Array.from) %)
+            (gen/vector (gen/choose -128 127))))
+
+(def gen-cid
+  (gen/fmap #(data/cid-link #?(:clj (byte-array %) :cljs (js/Int8Array.from %)))
+            (gen/vector (gen/choose -128 127) 1 32)))
+
+(def gen-scalar
+  (gen/one-of [(gen/return nil)
+               gen/boolean
+               gen/int
+               (gen/choose -9007199254740991 9007199254740991)
+               gen/string
+               gen-bytes
+               gen-cid]))
+
+(def gen-key
+  (gen/fmap keyword (gen/not-empty gen/string-alphanumeric)))
+
+(def gen-value
+  (gen/recursive-gen
+   (fn [inner]
+     (gen/one-of [(gen/vector inner)
+                  (gen/map gen-key inner)]))
+   gen-scalar))
+
+(defspec round-trip-decode-of-encode 100
+  (prop/for-all [v gen-value]
+    (data/eq? v (cbor/decode (cbor/encode v)))))
+
+(defspec round-trip-canonical-stability 100
+  (prop/for-all [v gen-value]
+    (let [encoded (cbor/encode v)]
+      (= (bytes->hex encoded)
+         (bytes->hex (cbor/encode (cbor/decode encoded)))))))

--- a/test/atproto/data/cbor_test.cljc
+++ b/test/atproto/data/cbor_test.cljc
@@ -14,6 +14,7 @@
   (:require #?@(:clj [[clojure.test :refer :all]
                       [clojure.java.io :as io]]
                 :cljs [[cljs.test :refer :all]])
+            [clojure.string :as str]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
@@ -62,6 +63,16 @@
   [a b]
   #?(:clj (byte-array (concat (seq a) (seq b)))
      :cljs (js/Int8Array.from (concat (array-seq a) (array-seq b)))))
+
+(defn- blen
+  [b]
+  #?(:clj (alength ^bytes b)
+     :cljs (.-length b)))
+
+(defn- slice-bytes
+  [b start end]
+  #?(:clj (byte-array (->> (seq b) (drop start) (take (- end start))))
+     :cljs (.slice b start end)))
 
 (defn- invalid-cbor?
   "Whether decoding the hex throws an InvalidCbor error."
@@ -302,7 +313,11 @@
   (testing "decode does not enforce sorted map keys"
     ;; {"aa" 2, "b" 1} in non-canonical key order
     (is (= {:aa 2 :b 1}
-           (cbor/decode (hex->bytes "a262616102616201"))))))
+           (cbor/decode (hex->bytes "a262616102616201")))))
+
+  (testing "slash as map key round-trips (TS parity; :/ is unqualified)"
+    (let [v {(keyword "/") true}]
+      (is (= v (cbor/decode (cbor/encode v)))))))
 
 ;; -----------------------------------------------------------------------------
 ;; decode-first / decode-multi
@@ -355,12 +370,24 @@
   (gen/fmap #(data/cid-link #?(:clj (byte-array %) :cljs (js/Int8Array.from %)))
             (gen/vector (gen/choose -128 127) 1 32)))
 
+(def multibyte-fragments
+  "UTF-8 torture fragments: 2/3/4-byte sequences, astral-plane characters,
+  combining marks, and a multi-codepoint grapheme cluster (emoji ZWJ)."
+  ["é" "ñ" "©" "⽘" "☎" "𓋓" "😀" "👨‍👩‍👧‍👧" "中文" "العربية" "𝒜" "ﬃ" "é"])
+
+(def gen-unicode-string
+  (gen/fmap str/join
+            (gen/vector (gen/one-of [(gen/fmap str gen/char-ascii)
+                                     (gen/elements multibyte-fragments)])
+                        0 20)))
+
 (def gen-scalar
   (gen/one-of [(gen/return nil)
                gen/boolean
                gen/int
                (gen/choose -9007199254740991 9007199254740991)
                gen/string
+               gen-unicode-string
                gen-bytes
                gen-cid]))
 
@@ -383,3 +410,121 @@
     (let [encoded (cbor/encode v)]
       (= (bytes->hex encoded)
          (bytes->hex (cbor/encode (cbor/decode encoded)))))))
+
+;; -----------------------------------------------------------------------------
+;; Insertion-order insensitivity (canonical key sort)
+;; -----------------------------------------------------------------------------
+
+(defn- array-map-of
+  "Build an array-map (which preserves insertion order) from [k v] entries."
+  [entries]
+  (apply array-map (mapcat identity entries)))
+
+(def gen-map-with-permutation
+  (gen/bind (gen/map gen-key gen-scalar)
+            (fn [m]
+              (gen/fmap (fn [perm] [(vec m) perm])
+                        (gen/shuffle (vec m))))))
+
+(defspec map-insertion-order-insensitivity 100
+  (prop/for-all [[entries perm] gen-map-with-permutation]
+    (= (bytes->hex (cbor/encode (array-map-of entries)))
+       (bytes->hex (cbor/encode (array-map-of perm))))))
+
+;; -----------------------------------------------------------------------------
+;; CID determinism (the property MST/commit code depends on)
+;; -----------------------------------------------------------------------------
+
+(defspec cid-for-determinism 100
+  (prop/for-all [v gen-value]
+    (= (data/format-cid (data/cid-for v))
+       (data/format-cid (data/cid-for (cbor/decode (cbor/encode v)))))))
+
+;; -----------------------------------------------------------------------------
+;; decode-first / decode-multi composition
+;; -----------------------------------------------------------------------------
+
+(defspec decode-multi-matches-folded-decode-first 50
+  (prop/for-all [vs (gen/vector gen-value 1 5)]
+    (let [encs (mapv cbor/encode vs)
+          buf (reduce concat-bytes encs)
+          multi (cbor/decode-multi buf)
+          [firsts lens] (loop [b buf
+                               firsts []
+                               lens []]
+                          (if (zero? (blen b))
+                            [firsts lens]
+                            (let [[v n] (cbor/decode-first b)]
+                              (recur (slice-bytes b n (blen b))
+                                     (conj firsts v)
+                                     (conj lens n)))))]
+      (and (= (count vs) (count multi) (count firsts))
+           (every? true? (map data/eq? vs multi))
+           (every? true? (map data/eq? vs firsts))
+           ;; decode-first consumes exactly the per-item encoded lengths
+           (= (mapv blen encs) lens)))))
+
+;; -----------------------------------------------------------------------------
+;; Every strict prefix of a valid item fails to decode
+;; -----------------------------------------------------------------------------
+
+(def gen-encoded-with-prefix-length
+  (gen/bind gen-value
+            (fn [v]
+              (let [b (cbor/encode v)]
+                (gen/fmap (fn [i] [b i])
+                          (gen/choose 0 (dec (blen b))))))))
+
+(defspec strict-prefix-always-throws 100
+  (prop/for-all [[b i] gen-encoded-with-prefix-length]
+    (try
+      (cbor/decode (slice-bytes b 0 i))
+      false
+      (catch #?(:clj Exception :cljs js/Error) e
+        (= "InvalidCbor" (:error (ex-data e)))))))
+
+;; -----------------------------------------------------------------------------
+;; Garbage fuzzing: decode is total — InvalidCbor or a normalizable value,
+;; never an unexpected exception
+;; -----------------------------------------------------------------------------
+
+(def gen-garbage
+  (gen/fmap #(#?(:clj byte-array :cljs js/Int8Array.from) %)
+            (gen/vector (gen/choose -128 127) 1 100)))
+
+(defspec garbage-decode-is-total 200
+  (prop/for-all [b gen-garbage]
+    (try
+      (let [v (cbor/decode b)]
+        ;; rare: random bytes happened to be valid CBOR; the value must
+        ;; normalize cleanly...
+        (try
+          (true? (data/eq? v (cbor/decode (cbor/encode v))))
+          (catch #?(:clj Exception :cljs js/Error) e
+            ;; ...except that decode accepts the full int64 range on the
+            ;; JVM while encode enforces the JS-safe range
+            (= "InvalidDataModel" (:error (ex-data e))))))
+      (catch #?(:clj Exception :cljs js/Error) e
+        (= "InvalidCbor" (:error (ex-data e)))))))
+
+;; -----------------------------------------------------------------------------
+;; UTF-8 torture: multi-byte strings as values and as map keys, where the
+;; byte-length-vs-char-length distinction matters for the canonical key sort
+;; -----------------------------------------------------------------------------
+
+(defspec unicode-string-round-trip 100
+  (prop/for-all [s gen-unicode-string]
+    (= s (cbor/decode (cbor/encode s)))))
+
+(def gen-unicode-key
+  ;; "/" is excluded: (keyword "a/b") is a *qualified* keyword, which is
+  ;; outside the atproto data model (::data/key) and rejected by encode.
+  (gen/fmap #(keyword (str/replace % "/" "_"))
+            (gen/not-empty gen-unicode-string)))
+
+(defspec unicode-map-keys-canonical-round-trip 100
+  (prop/for-all [m (gen/map gen-unicode-key gen/int)]
+    (let [encoded (cbor/encode m)]
+      (and (true? (data/eq? m (cbor/decode encoded)))
+           (= (bytes->hex encoded)
+              (bytes->hex (cbor/encode (cbor/decode encoded))))))))

--- a/test/atproto/data/json_test.cljc
+++ b/test/atproto/data/json_test.cljc
@@ -1,8 +1,14 @@
 (ns atproto.data.json-test
-  (:require #?(:clj [clojure.test :refer :all])
-            [clojure.spec.alpha :as s]
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [clojure.string :as str]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.crypto :as crypto]
             [atproto.data :as data]
             [atproto.data.json :as json]))
+
+;; $bytes value from interop fixture 2 (32 bytes, unpadded base64)
+(def fixture-bytes-b64 "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0")
 
 (deftest test-encoding-decoding
 
@@ -21,3 +27,37 @@
          :ref (data/blob-ref bytes)
          :mimeType "text/plain"
          :size 42}))))
+
+(deftest test-bytes-base64
+  (let [b (crypto/base64-decode fixture-bytes-b64)]
+
+    (testing "decodes to 32 bytes"
+      (is (= 32 #?(:clj (alength ^bytes b) :cljs (.-length b)))))
+
+    (testing "re-encodes without padding to the identical string"
+      (is (= fixture-bytes-b64 (crypto/base64-encode b))))
+
+    (testing "padded input also decodes"
+      (is (bytes/eq? b (crypto/base64-decode (str fixture-bytes-b64 "=")))))
+
+    (testing "invalid input decodes to nil"
+      (are [s] (nil? (crypto/base64-decode s))
+        "!!!"
+        "a"     ;; impossible length
+        "ab=c"  ;; padding in the middle
+        nil))
+
+    (testing "$bytes JSON form is unpadded"
+      (let [{:keys [$bytes]} (json/encode b)]
+        (is (= fixture-bytes-b64 $bytes))
+        (is (not (str/ends-with? $bytes "=")))))))
+
+(deftest test-legacy-blob-passthrough
+  ;; Legacy untyped blob refs are deliberately NOT special-cased by the
+  ;; JSON codec (TS parity): they round-trip as plain maps.
+  (let [legacy {:cid "bafkreiccldh766hwcnuxnf2wh6jgzepf2nlu2lvcllt63eww5p6chi4ity"
+                :mimeType "image/jpeg"}]
+    (is (= legacy (json/encode legacy)))
+    (is (= legacy (json/decode legacy)))
+    (is (= {:record legacy} (json/decode (json/encode {:record legacy}))))
+    (is (data/legacy-blob? (json/decode legacy)))))

--- a/test/atproto/data_test.cljc
+++ b/test/atproto/data_test.cljc
@@ -1,8 +1,29 @@
 (ns atproto.data-test
-  (:require #?(:clj [clojure.test :refer :all]
-               :cljs [cljs.test :refer :all])
+  (:require #?@(:clj [[clojure.test :refer :all]]
+                :cljs [[cljs.test :refer :all]
+                       [goog.crypt]])
             [clojure.spec.alpha :as s]
+            [multiformats.cid :as cid]
+            [multiformats.hash :as mhash]
             [atproto.data :as data]))
+
+(defn- hex->bytes
+  [s]
+  (let [ints (map (fn [[a b]]
+                    #?(:clj (Integer/parseInt (str a b) 16)
+                       :cljs (js/parseInt (str a b) 16)))
+                  (partition 2 s))]
+    #?(:clj (byte-array (map unchecked-byte ints))
+       :cljs (js/Int8Array.from (into-array ints)))))
+
+(defn- utf8-bytes
+  [s]
+  #?(:clj (.getBytes ^String s "UTF-8")
+     :cljs (js/Int8Array.from (goog.crypt/stringToUtf8ByteArray s))))
+
+;; sha256("hello world"), independently computed
+(def hello-world-sha256
+  "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
 
 (deftest test-validation
 
@@ -12,10 +33,10 @@
                :false false
                :integer 1
                :string "foobar"
-               :bytes (.getBytes "foobar")
-               :link (data/cid-link (.getBytes "foobar"))
+               :bytes (utf8-bytes "foobar")
+               :link (data/cid-link (utf8-bytes "foobar"))
                :blob {:$type "blob"
-                      :ref (data/blob-ref (.getBytes "foobar"))
+                      :ref (data/blob-ref (utf8-bytes "foobar"))
                       :mimeType "text/plain"
                       :size 42}}]
       (is (s/valid? ::data/value (-> obj
@@ -28,3 +49,73 @@
       data/js-max-integer
       (dec (- data/js-max-integer))
       {:$type "blob"})))
+
+(deftest test-cid-known-answers
+  ;; These known-answer tests pin the fix for the mhash/create bug:
+  ;; cid-link/blob-ref must *hash* the input, not wrap it as a digest.
+  (let [content (utf8-bytes "hello world")
+        digest (hex->bytes hello-world-sha256)]
+
+    (testing "blob-ref hashes the content (raw 0x55, sha2-256)"
+      (let [c (data/blob-ref content)]
+        (is (= (cid/create :raw (mhash/create :sha2-256 digest)) c))
+        (is (data/blob-ref? c))))
+
+    (testing "cid-link hashes the bytes (dag-cbor 0x71, sha2-256)"
+      (let [c (data/cid-link content)]
+        (is (= (cid/create :ipld-cbor (mhash/create :sha2-256 digest)) c))
+        (is (data/cid-link? c))))))
+
+(deftest test-verify-cid
+  (let [content (utf8-bytes "hello world")]
+
+    (testing "sha2-256 match"
+      (is (true? (data/verify-cid (data/blob-ref content) content)))
+      (is (true? (data/verify-cid (data/cid-link content) content))))
+
+    (testing "sha2-512 match"
+      (is (true? (data/verify-cid (cid/create :raw (mhash/sha2-512 content))
+                                  content))))
+
+    (testing "mismatch"
+      (let [other (utf8-bytes "something else")
+            res (data/verify-cid (data/blob-ref content) other)]
+        (is (= "CidMismatch" (:error res)))
+        (is (= (data/format-cid (data/blob-ref content)) (:expected res)))
+        (is (= (data/format-cid (data/blob-ref other)) (:actual res)))))
+
+    (testing "unsupported hash algorithm"
+      (let [res (data/verify-cid (cid/create :raw (mhash/md5 content)) content)]
+        (is (= "UnsupportedHashAlgorithm" (:error res)))))))
+
+(deftest test-legacy-blob
+  (let [valid {:cid "bafkreiccldh766hwcnuxnf2wh6jgzepf2nlu2lvcllt63eww5p6chi4ity"
+               :mimeType "image/jpeg"}]
+
+    (testing "legacy-blob? accepts the legacy untyped shape"
+      (is (data/legacy-blob? valid))
+      (is (s/valid? ::data/legacy-blob valid)))
+
+    (testing "legacy-blob? rejections"
+      (are [v] (not (data/legacy-blob? v))
+        nil
+        "string"
+        {}
+        (assoc valid :extra "key")
+        (assoc valid :cid "not-a-cid")
+        (assoc valid :cid 42)
+        (assoc valid :mimeType "")
+        (dissoc valid :mimeType)
+        (dissoc valid :cid)))
+
+    (testing "upgrade-legacy-blob produces the typed form with :size -1"
+      (let [{:keys [$type ref mimeType size] :as upgraded} (data/upgrade-legacy-blob valid)]
+        (is (= "blob" $type))
+        (is (= (data/parse-cid (:cid valid)) ref))
+        (is (= "image/jpeg" mimeType))
+        (is (= -1 size))
+        (is (= #{:$type :ref :mimeType :size} (set (keys upgraded))))))
+
+    (testing "upgrade-legacy-blob returns nil on invalid input"
+      (is (nil? (data/upgrade-legacy-blob {:cid "not-a-cid" :mimeType "image/jpeg"})))
+      (is (nil? (data/upgrade-legacy-blob nil))))))

--- a/test/atproto/runtime/varint_test.cljc
+++ b/test/atproto/runtime/varint_test.cljc
@@ -1,0 +1,47 @@
+(ns atproto.runtime.varint-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [multiformats.varint :as mf.varint]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.runtime.varint :as varint]))
+
+(deftest test-round-trip
+  (doseq [n [0 1 127 128 255 300 16383 16384 65536
+             ;; CAR-realistic block sizes
+             1048576 16777216
+             2147483647]]
+    (testing (str "round-trip " n)
+      (is (= n (varint/decode (varint/encode n)))))))
+
+(deftest test-known-encodings
+  (are [bs n] (bytes/eq? #?(:clj (byte-array bs)
+                            :cljs (js/Int8Array.from (into-array bs)))
+                         (varint/encode n))
+    [0x00] 0
+    [0x01] 1
+    [0x7f] 127
+    [-0x80 0x01] 128       ;; 0x80 0x01
+    [-0x01 0x7f] 16383))   ;; 0xff 0x7f
+
+(deftest test-matches-multiformats
+  (doseq [n [0 1 127 128 16383 16384 123456789]]
+    (is (bytes/eq? (mf.varint/encode n) (varint/encode n)))
+    (is (= (mf.varint/decode (mf.varint/encode n))
+           (varint/decode (varint/encode n))))))
+
+(deftest test-read-bytes
+  (testing "reads at an offset and returns [value bytes-read]"
+    (let [b #?(:clj (byte-array [0x00 -0x54 0x02])  ;; 0x00, then varint 300 (0xac 0x02)
+               :cljs (js/Int8Array.from #js [0x00 -0x54 0x02]))]
+      (is (= [300 2] (varint/read-bytes b 1)))))
+
+  (testing "decode ignores trailing bytes"
+    (let [b #?(:clj (byte-array [0x05 0x42])
+               :cljs (js/Int8Array.from #js [0x05 0x42]))]
+      (is (= 5 (varint/decode b)))))
+
+  (testing "throws on truncated varint"
+    (let [b #?(:clj (byte-array [-0x80])  ;; lone continuation byte 0x80
+               :cljs (js/Int8Array.from #js [-0x80]))]
+      (is (thrown? #?(:clj Exception :cljs js/Error)
+                   (varint/read-bytes b 0))))))

--- a/test/interop-test-files/README.md
+++ b/test/interop-test-files/README.md
@@ -7,3 +7,12 @@ This directory contains reusable files for testing interoperability and specific
 The protocol itself is documented at <https://atproto.com/specs/atp>. If there are conflicts or ambiguity between these test files and the specs, the specs are the authority, and these test files should usually be corrected.
 
 These files are intended to be simple (JSON, text files, etc) and mostly self-documenting.
+
+## data-model/
+
+`data-model/data-model-fixtures.json` is vendored verbatim from the TypeScript
+reference implementation at
+`bluesky-social/atproto:packages/lex/lex-cbor/tests/data-model-fixtures.json`
+(commit `3e977fe`). Each fixture is `{json, cbor_base64, cid}`: the canonical
+DAG-CBOR encoding (base64, unpadded) and CIDv1 (dag-cbor, sha2-256) of the
+JSON-form data.

--- a/test/interop-test-files/data-model/data-model-fixtures.json
+++ b/test/interop-test-files/data-model/data-model-fixtures.json
@@ -1,0 +1,64 @@
+[
+  {
+    "json": {
+      "string": "abc",
+      "unicode": "a~öñ©⽘☎𓋓😀👨‍👩‍👧‍👧",
+      "integer": 123,
+      "bool": true,
+      "null": null,
+      "array": ["abc", "def", "ghi"],
+      "object": {
+        "string": "abc",
+        "number": 123,
+        "bool": true,
+        "arr": ["abc", "def", "ghi"]
+      }
+    },
+    "cbor_base64": "p2Rib29s9WRudWxs9mVhcnJheYNjYWJjY2RlZmNnaGlmb2JqZWN0pGNhcnKDY2FiY2NkZWZjZ2hpZGJvb2z1Zm51bWJlchh7ZnN0cmluZ2NhYmNmc3RyaW5nY2FiY2dpbnRlZ2VyGHtndW5pY29kZXgvYX7DtsOxwqnivZjimI7wk4uT8J+YgPCfkajigI3wn5Gp4oCN8J+Rp+KAjfCfkac",
+    "cid": "bafyreiclp443lavogvhj3d2ob2cxbfuscni2k5jk7bebjzg7khl3esabwq"
+  },
+  {
+    "json": {
+      "a": {
+        "$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+      },
+      "b": {
+        "$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0"
+      },
+      "c": {
+        "$type": "blob",
+        "ref": {
+          "$link": "bafkreiccldh766hwcnuxnf2wh6jgzepf2nlu2lvcllt63eww5p6chi4ity"
+        },
+        "mimeType": "image/jpeg",
+        "size": 10000
+      }
+    },
+    "cbor_base64": "o2Fh2CpYJQABcRIgZQYqWloA/BbXPGlEI3zLwVscSnI0SJM2iR0JF0GiOdBhYlggnFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI1hY6RjcmVm2CpYJQABVRIgQljP/3j2E2l2l1Y/kmyR5dNXTS6iWuftktbr/COjiJ5kc2l6ZRknEGUkdHlwZWRibG9iaG1pbWVUeXBlamltYWdlL2pwZWc",
+    "cid": "bafyreihldkhcwijkde7gx4rpkkuw7pl6lbyu5gieunyc7ihactn5bkd2nm"
+  },
+  {
+    "json": {
+      "a": {
+        "b": [
+          {
+            "d": [
+              {
+                "$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+              },
+              {
+                "$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+              }
+            ],
+            "e": [
+              { "$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0" },
+              { "$bytes": "iE+sPoHobU9tSIqGI+309LLCcWQIRmEXwxcoDt19tas" }
+            ]
+          }
+        ]
+      }
+    },
+    "cbor_base64": "oWFhoWFigaJhZILYKlglAAFxEiBlBipaWgD8Ftc8aUQjfMvBWxxKcjRIkzaJHQkXQaI50NgqWCUAAXESIGUGKlpaAPwW1zxpRCN8y8FbHEpyNEiTNokdCRdBojnQYWWCWCCcURGO8suLD2qbjkmuof1BPPILYu7Vdvid7r6wGsLMjVggiE+sPoHobU9tSIqGI+309LLCcWQIRmEXwxcoDt19tas",
+    "cid": "bafyreid3imdulnhgeytpf6uk7zahjvrsqlofkmm5b5ub2maw4kqus6jp4i"
+  }
+]


### PR DESCRIPTION
Implements [docs/planning/02-dag-cbor-data-model.md](docs/planning/02-dag-cbor-data-model.md) (WS-02, P0), ported from the TypeScript reference implementation (`bluesky-social/atproto` `packages/lex/lex-cbor` + `lex-data`, commit `3e977fe`).

## What's included

**New `atproto.data.cbor`** (`.cljc`, hand-rolled per the doc's Risk 1 recommendation — no new dependencies): `encode`, `decode`, `decode-first`, `decode-multi`.
- Canonical encode: definite lengths only, shortest-form heads, map keys sorted length-first then bytewise, CIDs as tag 42 with the `0x00` identity-multibase prefix, no floats, integers limited to ±(2^53 − 1).
- Strict decode: rejects indefinite lengths, non-shortest-form encodings, duplicate map keys, all floats (stricter than TS, per the atproto data-model spec), unknown tags/simple values, bad tag-42 payloads, truncation, and trailing bytes (for `decode`); coerces `0xf7` (undefined) to nil. Decode does **not** enforce sorted map keys (TS parity) — verification must hash original bytes.
- Invalid input throws `ex-info` carrying `{:error "InvalidDataModel" ... :path ...}` / `{:error "InvalidCbor" ... :offset ...}` per the frozen §4.1 contract.

**`atproto.data`**
- Fixes the `cid-link`/`blob-ref` hashing bug: both now call `mhash/sha2-256` (which hashes) instead of `mhash/create` (which wraps an already-computed digest). ⚠️ Behavioral change: any branch creating CIDs should rebase onto this rather than copy the old call.
- Adds `cid-for` (data → CIDv1/dag-cbor/sha2-256) and `verify-cid` (`true` | `{:error "CidMismatch"}` | `{:error "UnsupportedHashAlgorithm"}`; sha2-256 and sha2-512).
- Adds `::data/legacy-blob` spec, `legacy-blob?`, and `upgrade-legacy-blob` (legacy → typed blob with `:size -1`). JSON/CBOR codecs pass legacy blobs through as plain maps (TS parity).
- Replaces the TODO at the old `data.cljc:144` with the documented decision: raw platform byte arrays, no wrapper type, `data/eq?` as the structural-equality entry point.

**Runtime fixes**
- New `atproto.runtime.varint` wrapping `multiformats.varint` (`encode`/`decode`/`read-bytes`) for WS-04/WS-05.
- `atproto.runtime.crypto/base64-encode` now takes bytes (proper `^bytes` hint) and emits **unpadded** standard base64 (the `$bytes` form); `base64-decode` accepts padded or unpadded input and returns nil on invalid input; both gain `:cljs` branches (`goog.crypt.base64`).
- `atproto.runtime.bytes/eq?` gains a `:cljs` branch.

## Testing

- Vendored `data-model-fixtures.json` verbatim into `test/interop-test-files/data-model/` (provenance in the README). All 3 fixtures pass: byte-exact `encode`, CID-exact `cid-for`/`cid-link`, single-item `decode-multi`, JSON round-trip, `verify-cid`.
- Strictness vectors ported as hex literals from `dag-cbor.test.ts`/`codec.test.ts` (floats/NaN/±Inf, duplicate keys, bad CID lead-in, indefinite lengths, non-shortest forms, truncation, trailing bytes, `f7` coercion, platform integer bounds).
- Canonical-form unit tests (head boundaries, key ordering incl. multi-byte UTF-8, tag-42 byte pattern), `decode-first`/`decode-multi` concatenation/truncation tests, varint round-trip + byte-for-byte cross-check, CID known-answer tests pinning the hashing fix (independent sha256 digest), unpadded `$bytes` and legacy-blob passthrough tests.
- 2×100 generative round-trip properties (`decode(encode(v))` equality and canonical stability).
- `clojure -X:test`: **65 tests, 1100 assertions, 0 failures.**
- Manual live check performed and documented in the `atproto.data.cbor-test` ns docstring: `com.atproto.repo.getRecord` against bsky.social reproduces the server CID exactly.

All 11 acceptance criteria in the planning doc are ticked (cljs CI execution stays deferred to WS-10 as scoped). The frozen §4.1 interface contract is now fully usable by WS-04/05/06/08/09.

https://claude.ai/code/session_019n3cgfwbpzoziPzdmBPASG

---
_Generated by [Claude Code](https://claude.ai/code/session_019n3cgfwbpzoziPzdmBPASG)_