### PR TITLE
WS-08: Service Auth & XRPC Server Completion

### DIFF
--- a/docs/planning/08-service-auth-xrpc-server.md
+++ b/docs/planning/08-service-auth-xrpc-server.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Planning |
+| **Status** | Implemented on `claude/epic-cannon-wwck1e` (2026-06-11); pending live-PDS check (acceptance item 4) |
 | **Priority** | P1 |
 | **Estimated size** | M |
 | **Branch** | ws/08-service-auth-xrpc-server |
@@ -479,17 +479,17 @@ Run everything with `clj -X:test` (cognitect test-runner, already configured in 
 
 ## Acceptance criteria
 
-- [ ] `atproto.service-auth/create-jwt` produces tokens that `packages/xrpc-server` `verifyJwt` accepts (validated via the generated fixture suite in both directions).
-- [ ] `verify-jwt` accepts reference-minted fixture tokens and returns claims; every reference error name (`BadJwt`, `BadJwtType`, `JwtExpired`, `BadJwtAudience`, `BadJwtLexiconMethod`, `BadJwtIss`, `BadJwtSignature`) is produced by a test and carries `:status 401`.
-- [ ] Signature-failure path retries exactly once with `force-refresh? true` and only when the refreshed key differs.
-- [ ] `get-service-auth` returns `{:token ...}` from a real PDS (manual live check documented and performed once before merge).
-- [ ] `service-auth/session` attaches `Bearer` service JWTs with `lxm` = request NSID; verified by round-tripping against the SDK's own server with `service-auth-verifier`.
-- [ ] XRPC server: routes can declare auth; `handle` receives `:auth`; auth runs before input validation; unauthenticated routes unchanged (existing server tests still pass).
-- [ ] Error responses: JSON body always `{"error": <name>, "message": <msg>}`; status table matches `ResponseType` (400/401/403/404/406/413/415/429/500/501/502/503/504); unknown method → 501; malformed xrpc path → 400; 5xx bodies never contain internal exception messages; `clojure.edn` is properly required.
-- [ ] `atproto.xrpc.frames` encode/decode byte-exact against vendored reference fixtures.
-- [ ] A lexicon subscription endpoint served over http-kit streams binary frames to a vanilla websocket client, with error-frame + close 1008 and normal close 1000 semantics.
-- [ ] `RateLimiter` protocol exists, is invoked at the documented points, maps exceeded → 429; no production limiter shipped.
-- [ ] `clj -X:test` green on every merged PR; cljs compilation of touched .cljc namespaces not broken (service-auth/frames may be JVM-stubbed under `#?` like `runtime/jwt.cljc` is today, but must still read as cljc).
+- [x] `atproto.service-auth/create-jwt` produces tokens that `packages/xrpc-server` `verifyJwt` accepts (validated via the generated fixture suite in both directions).
+- [x] `verify-jwt` accepts reference-minted fixture tokens and returns claims; every reference error name (`BadJwt`, `BadJwtType`, `JwtExpired`, `BadJwtAudience`, `BadJwtLexiconMethod`, `BadJwtIss`, `BadJwtSignature`) is produced by a test and carries `:status 401`.
+- [x] Signature-failure path retries exactly once with `force-refresh? true` and only when the refreshed key differs.
+- [ ] `get-service-auth` returns `{:token ...}` from a real PDS (not performed: no live credentials in the implementation environment; instructions in the test ns comment block) (manual live check documented and performed once before merge).
+- [x] `service-auth/session` attaches `Bearer` service JWTs with `lxm` = request NSID; verified by round-tripping against the SDK's own server with `service-auth-verifier`.
+- [x] XRPC server: routes can declare auth; `handle` receives `:auth`; auth runs before input validation; unauthenticated routes unchanged (existing server tests still pass).
+- [x] Error responses: JSON body always `{"error": <name>, "message": <msg>}`; status table matches `ResponseType` (400/401/403/404/406/413/415/429/500/501/502/503/504); unknown method → 501; malformed xrpc path → 400; 5xx bodies never contain internal exception messages; `clojure.edn` is properly required.
+- [x] `atproto.xrpc.frames` encode/decode byte-exact against vendored reference fixtures.
+- [x] A lexicon subscription endpoint served over http-kit streams binary frames to a vanilla websocket client, with error-frame + close 1008 and normal close 1000 semantics.
+- [x] `RateLimiter` protocol exists, is invoked at the documented points, maps exceeded → 429; no production limiter shipped.
+- [x] `clj -X:test` green on every merged PR; cljs compilation of touched .cljc namespaces not broken (service-auth/frames may be JVM-stubbed under `#?` like `runtime/jwt.cljc` is today, but must still read as cljc).
 
 ## Milestones
 
@@ -499,6 +499,23 @@ Run everything with `clj -X:test` (cognitect test-runner, already configured in 
 4. **PR-4: frames.** `atproto.xrpc.frames` + vendored byte fixtures. **Gated on WS-02 contract merge**; if WS-02 slips, this PR carries the ns + tests behind a pending flag with a temporary test-only CBOR shim and is explicitly noted as such.
 5. **PR-5: websocket subscription transport.** `handle-subscription`, `subscription-request`, http-kit upgrade path in `ring.clj`, integration test with a countdown stream + auth + error-frame close codes.
 6. **PR-6 (small): polish.** Live-service verification write-up, docstrings, `cast/event`s at auth/subscription lifecycle points, README progress-matrix update *proposal* left to the orchestrator (README not owned by this workstream).
+
+## Implementation notes (2026-06-11)
+
+- Implemented against the merged WS-02/WS-03 contracts (no stubs needed); WS-06 not yet
+  merged, so `did-signing-key-resolver` runs against the current `identity/resolve-did`
+  and forwards `:force-refresh` for forward compatibility (its `:resolve-did` override is
+  the test seam).
+- http-kit's `AsyncChannel.serverClose` encodes only the 2-byte close status; the close
+  *reason* string cannot be attached (the `serverClose(int, String)` overload ignores the
+  reason). Close codes 1008/1000 are sent per the reference; the error name reaches
+  clients in the error frame body. Documented in `atproto.xrpc.server.ring`.
+- Cross-implementation fixtures: `test/atproto/service_auth/jwt_fixtures.json` generated
+  from `@atproto/xrpc-server` 0.11.1 / `@atproto/crypto` 0.5.0 (script committed beside
+  it); the reverse direction (Clojure-minted tokens verified by the reference `verifyJwt`)
+  was performed for both curves at implementation time.
+- WS-05 had not landed `atproto.sync.frame`; `atproto.xrpc.frames` is the only frame
+  codec, as required by overview §4.9 item 8.
 
 ## Risks & open questions
 

--- a/src/atproto/service_auth.cljc
+++ b/src/atproto/service_auth.cljc
@@ -1,0 +1,391 @@
+(ns atproto.service-auth
+  "Mint and verify atproto inter-service JWTs (iss/aud/lxm/exp/jti).
+
+  Service JWTs are short-lived bearer tokens signed directly with an
+  atproto signing keypair (ES256/ES256K), used to authenticate requests
+  between atproto services. Mirrors the reference implementation in
+  packages/xrpc-server/src/auth.ts.
+
+  All async functions follow the SDK convention: trailing kwarg opts
+  with :callback/:promise/:channel adapters; errors are
+  {:error \"Name\" :message ... :status 401} maps, never thrown."
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.http :as http]
+            [atproto.runtime.crypto :as runtime-crypto]
+            [atproto.runtime.jwt :as jwt]
+            [atproto.runtime.cast :as cast]
+            [atproto.crypto :as crypto]
+            [atproto.identity :as identity]
+            [atproto.lexicon :as lexicon]
+            [atproto.xrpc.client :as xrpc-client]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- async-opts
+  "The async-adapter keys of an options map (see i/platform-async)."
+  [opts]
+  (select-keys opts [:channel :callback :promise]))
+
+;; -----------------------------------------------------------------------------
+;; Claims
+;; -----------------------------------------------------------------------------
+
+(defn- did-or-service?
+  "True for a DID, or a DID with a single non-empty #serviceId fragment
+  (e.g. \"did:web:example.com#atproto_labeler\")."
+  [v]
+  (and (string? v)
+       (if-let [idx (str/index-of v "#")]
+         (and (< (inc idx) (count v))
+              (not (str/index-of v "#" (inc idx)))
+              (s/valid? ::lexicon/did (subs v 0 idx)))
+         (s/valid? ::lexicon/did v))))
+
+(s/def ::iss did-or-service?)
+(s/def ::aud did-or-service?)
+(s/def ::lxm (s/nilable ::lexicon/nsid))
+(s/def ::exp pos-int?)
+(s/def ::iat pos-int?)
+(s/def ::keypair #(satisfies? crypto/Keypair %))
+(s/def ::create-jwt-params
+  (s/keys :req-un [::iss ::aud ::keypair]
+          :opt-un [::lxm ::exp ::iat]))
+
+(def ^:private forbidden-typs
+  "JWT `typ` header values that must never be accepted as service tokens:
+  OAuth 2.0 access tokens (RFC 9068), @atproto refresh tokens, and DPoP
+  proofs (RFC 9449)."
+  #{"at+jwt" "refresh+jwt" "dpop+jwt"})
+
+;; -----------------------------------------------------------------------------
+;; Minting
+;; -----------------------------------------------------------------------------
+
+(defn create-jwt
+  "Mint a service JWT.
+
+  `params`:
+  :iss      (required) issuer DID, optionally with #serviceId fragment.
+  :aud      (required) audience DID (or did#serviceId).
+  :keypair  (required) atproto.crypto signing keypair (provides alg + sign).
+  :lxm      NSID of the method this token is bound to. Strongly recommended.
+  :exp      expiration, seconds since epoch. Default: iat + 60.
+  :iat      issued-at, seconds since epoch. Default: now.
+
+  Async; yields {:token \"<jwt>\"} or {:error ...}.
+  A fresh 16-byte hex :jti claim is generated for every token."
+  [params & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))
+        {:keys [iss aud keypair lxm exp iat]} params]
+    (if (not (s/valid? ::create-jwt-params params))
+      (cb {:error "InvalidServiceJwtParams"
+           :message (s/explain-str ::create-jwt-params params)})
+      (let [iat (or iat (runtime-crypto/now))
+            exp (or exp (+ iat 60))
+            jti (runtime-crypto/hex-encode (runtime-crypto/random-bytes 16))
+            claims (cond-> {:iat iat
+                            :iss iss
+                            :aud aud
+                            :exp exp}
+                     lxm (assoc :lxm lxm)
+                     true (assoc :jti jti))]
+        (jwt/sign keypair {:typ "JWT"} claims
+                  :callback (fn [resp]
+                              (cb (if (:error resp)
+                                    resp
+                                    {:token resp}))))))
+    val))
+
+(defn auth-headers
+  "Async; yields {:headers {:authorization \"Bearer <jwt>\"}} for `create-jwt` params."
+  [params & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (create-jwt params
+                :callback (fn [{:keys [error token] :as resp}]
+                            (cb (if error
+                                  resp
+                                  {:headers {:authorization (str "Bearer " token)}}))))
+    val))
+
+;; -----------------------------------------------------------------------------
+;; Verification
+;; -----------------------------------------------------------------------------
+
+(defn- auth-error
+  [error message]
+  {:error error :message message :status 401})
+
+(defn- with-401
+  "Ensure an error map carries an HTTP status (default 401)."
+  [error-map]
+  (cond-> error-map
+    (not (:status error-map)) (assoc :status 401)))
+
+(def ^:private bad-jwt (auth-error "BadJwt" "poorly formatted jwt"))
+
+(defn- claims-shape-error
+  "Structural validation of the service-JWT payload (reference parsePayload)."
+  [{:keys [iss aud exp lxm] :as claims}]
+  (when (or (not (string? iss))
+            (not (string? aud))
+            (not (number? exp))
+            (and (some? lxm) (not (string? lxm))))
+    bad-jwt))
+
+(defn- policy-error
+  "The pre-signature policy checks, in reference order. Returns an error
+  map or nil. `aud`/`lxm` are the expected values; nil skips the check."
+  [{:keys [header claims]} {:keys [aud lxm now]}]
+  (let [now (or now (runtime-crypto/now))]
+    (cond
+      (not (string? (:alg header)))
+      bad-jwt
+
+      (contains? forbidden-typs (:typ header))
+      (auth-error "BadJwtType" (str "Invalid jwt type " (pr-str (:typ header))))
+
+      (claims-shape-error claims)
+      (claims-shape-error claims)
+
+      (> now (:exp claims))
+      (auth-error "JwtExpired" "jwt expired")
+
+      (and (some? aud) (not= aud (:aud claims)))
+      (auth-error "BadJwtAudience" "jwt audience does not match service did")
+
+      (and (some? lxm) (not= lxm (:lxm claims)))
+      (auth-error "BadJwtLexiconMethod"
+                  (if (some? (:lxm claims))
+                    (str "bad jwt lexicon method (\"lxm\"). must match: " lxm)
+                    (str "missing jwt lexicon method (\"lxm\"). must match: " lxm)))
+
+      (not (did-or-service? (:iss claims)))
+      (auth-error "BadJwtIss" "jwt iss is not a valid did"))))
+
+(defn- check-signature
+  "Run the signature check; cb receives true, false, or an error map
+  already translated to BadJwtSignature."
+  [verify-signature {:keys [header signing-input signature]} did-key cb]
+  (verify-signature did-key signature signing-input
+                    :alg (:alg header)
+                    :allow-malleable? true
+                    :callback
+                    (fn [result]
+                      (cb (if (map? result)
+                            (auth-error "BadJwtSignature" "could not verify jwt signature")
+                            result)))))
+
+(defn verify-jwt
+  "Verify a service JWT string and return its claims.
+
+  `opts-map`:
+  :aud              own service DID; nil skips the audience check.
+  :lxm              expected method NSID; nil skips the lxm check.
+  :get-signing-key  (required) (fn [iss force-refresh? cb]) yielding
+                    {:key \"did:key:...\"} or {:error ...}. Called a second
+                    time with force-refresh? true when signature
+                    verification fails (key rotation).
+  :verify-signature optional override for the raw signature check
+                    (tests/stubs). Same signature as the default,
+                    atproto.crypto/verify-did-sig:
+                    (fn [did-key sig-bytes msg-bytes & {:keys [alg
+                     allow-malleable? callback]}]) yielding boolean or
+                    {:error ...}. Called with :allow-malleable? true
+                    (service-JWT parity).
+
+  Async; yields the payload {:iss :aud :exp :iat :lxm :jti ...} on success,
+  or {:error <Name> :message ... :status 401} where <Name> is one of:
+  BadJwt, BadJwtType, JwtExpired, BadJwtAudience, BadJwtLexiconMethod,
+  BadJwtIss, BadJwtSignature (or the :get-signing-key fn's own error,
+  e.g. UntrustedIss)."
+  [jwt {:keys [get-signing-key verify-signature] :as opts-map} & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))
+        verify-signature (or verify-signature crypto/verify-did-sig)
+        parsed (jwt/parse jwt)]
+    (cond
+      (or (nil? parsed) (:error parsed))
+      (cb bad-jwt)
+
+      :else
+      (if-let [error (policy-error parsed opts-map)]
+        (cb error)
+        (let [claims (:claims parsed)
+              fail (auth-error "BadJwtSignature"
+                               "jwt signature does not match jwt issuer")]
+          (get-signing-key
+           (:iss claims) false
+           (fn [{:keys [error key] :as resp}]
+             (if error
+               (cb (with-401 resp))
+               (check-signature
+                verify-signature parsed key
+                (fn [result]
+                  (cond
+                    (true? result) (cb claims)
+                    (map? result)  (cb result)
+                    :else
+                    ;; The signature failed against the cached key; re-resolve
+                    ;; with force-refresh in case of a recent key rotation and
+                    ;; retry once, only if the key actually changed.
+                    (get-signing-key
+                     (:iss claims) true
+                     (fn [{:keys [error] fresh-key :key :as resp}]
+                       (cond
+                         error (cb (with-401 resp))
+                         (= fresh-key key) (cb fail)
+                         :else (check-signature
+                                verify-signature parsed fresh-key
+                                (fn [result]
+                                  (cond
+                                    (true? result) (cb claims)
+                                    (map? result)  (cb result)
+                                    :else          (cb fail))))))))))))))))
+    val))
+
+;; -----------------------------------------------------------------------------
+;; DID-document signing-key resolution
+;; -----------------------------------------------------------------------------
+
+(defn- verification-material
+  "The verification method in the DID doc whose id ends in #<key-id>,
+  or nil (reference getVerificationMaterial)."
+  [did-doc key-id]
+  (->> (:verificationMethod did-doc)
+       (filter (fn [{:keys [id publicKeyMultibase]}]
+                 (and (string? id)
+                      (str/ends-with? id (str "#" key-id))
+                      (string? publicKeyMultibase))))
+       (first)))
+
+(defn- multibase-material->did-key
+  "did:key string for a DID-doc verification method, or {:error ...}.
+  Composition per overview §4.2 / reference getDidKeyFromMultibase."
+  [{:keys [type publicKeyMultibase]}]
+  (case type
+    "Multikey"
+    (let [{:keys [error alg bytes] :as parsed} (crypto/parse-multikey publicKeyMultibase)]
+      (if error parsed (crypto/pubkey->did-key alg bytes)))
+
+    ("EcdsaSecp256r1VerificationKey2019" "EcdsaSecp256k1VerificationKey2019")
+    (let [alg (if (= type "EcdsaSecp256r1VerificationKey2019") "ES256" "ES256K")
+          bytes (crypto/multibase->bytes publicKeyMultibase)]
+      (if (map? bytes) bytes (crypto/pubkey->did-key alg bytes)))
+
+    {:error "UnsupportedKeyType"
+     :message (str "Unsupported verification method type: " (pr-str type))}))
+
+(defn did-signing-key-resolver
+  "Build a :get-signing-key fn backed by atproto.identity DID resolution.
+
+  Resolves the issuer's DID document and extracts the did:key for the
+  verification method `#atproto` (or `#atproto_label` when iss has the
+  #atproto_labeler service fragment), per the reference PDS.
+
+  `opts-map`:
+  :allowed-issuers  optional collection of permitted iss values (incl.
+                    fragments); others yield {:error \"UntrustedIss\"
+                    :status 401}.
+  :resolve-did      optional resolution override (tests/stubs); same
+                    async signature as atproto.identity/resolve-did
+                    (the default). The :force-refresh kwarg is forwarded;
+                    today's resolver has no cache and ignores it, and the
+                    WS-06 cache-aware behavior is picked up transparently."
+  [{:keys [allowed-issuers resolve-did] :as opts-map}]
+  (let [resolve-did (or resolve-did identity/resolve-did)
+        allowed (when allowed-issuers (set allowed-issuers))]
+    (fn [iss force-refresh? cb]
+      (if (and allowed (not (contains? allowed iss)))
+        (cb (auth-error "UntrustedIss" "Untrusted issuer"))
+        (let [[did service-id] (str/split iss #"#" 2)
+              key-id (if (= "atproto_labeler" service-id)
+                       "atproto_label"
+                       "atproto")]
+          (resolve-did did
+                       :force-refresh (boolean force-refresh?)
+                       :callback
+                       (fn [{:keys [error did-doc] :as resp}]
+                         (cb (if error
+                               (auth-error "AuthenticationRequired"
+                                           "could not resolve iss did")
+                               (let [material (verification-material did-doc key-id)
+                                     did-key (when material
+                                               (multibase-material->did-key material))]
+                                 (if (or (nil? did-key) (:error did-key))
+                                   (auth-error "AuthenticationRequired"
+                                               "missing or bad key in did doc")
+                                   {:key did-key})))))))))))
+
+;; -----------------------------------------------------------------------------
+;; Client side
+;; -----------------------------------------------------------------------------
+
+(defn get-service-auth
+  "Ask the user's PDS to mint a service token on their behalf
+  (com.atproto.server.getServiceAuth).
+
+  `client` is an authenticated atproto.client/xrpc client.
+  `params`: {:aud ... :lxm ... :exp ...} per the lexicon.
+  Async; yields {:token \"...\"} or the XRPC error (e.g. BadExpiration)."
+  [client params & {:as opts}]
+  (let [[cb val] (i/platform-async (async-opts opts))]
+    (xrpc-client/query client
+                       {:nsid "com.atproto.server.getServiceAuth"
+                        :params params}
+                       :callback cb)
+    val))
+
+(defn- request-nsid
+  "The NSID from an /xrpc/<nsid> request URL, or nil."
+  [url]
+  (when-let [path (:path (http/parse-url url))]
+    (when (str/starts-with? path "/xrpc/")
+      (not-empty (subs path (count "/xrpc/"))))))
+
+(defn- session-auth-interceptor
+  [{:keys [iss aud keypair] :as sess}]
+  {::i/name ::auth-interceptor
+   ::i/enter (fn [{:keys [::i/request] :as ctx}]
+               (create-jwt {:iss iss
+                            :aud aud
+                            :keypair keypair
+                            :lxm (request-nsid (:url request))}
+                           :callback
+                           (fn [{:keys [error token] :as resp}]
+                             (i/continue
+                              (if error
+                                (assoc ctx ::i/response resp)
+                                (assoc-in ctx
+                                          [::i/request :headers :authorization]
+                                          (str "Bearer " token))))))
+               nil)})
+
+(defn- session-refresh-token
+  "WS-01 Session contract: cb is called exactly once. There is no refresh
+  state to update — every request mints a fresh short-lived token — so the
+  session itself is the \"refreshed\" session and the retried request
+  re-mints."
+  [sess cb]
+  (cb sess))
+
+(defn session
+  "An xrpc-client Session that authenticates requests with self-minted
+  service JWTs (for services that hold their own signing key).
+
+  config:
+  :iss      issuer DID (this service).
+  :keypair  atproto.crypto signing keypair.
+  :aud      audience DID of the target service.
+  :service  target service URL (becomes the session :pds).
+
+  The auth interceptor derives :lxm from the request URL's /xrpc/<nsid>
+  path and mints a fresh short-lived token per request."
+  [{:keys [iss aud keypair service] :as config}]
+  (with-meta
+    {:iss iss
+     :aud aud
+     :keypair keypair
+     :pds service}
+    {`xrpc-client/auth-interceptor session-auth-interceptor
+     `xrpc-client/refresh-token session-refresh-token}))

--- a/src/atproto/xrpc/frames.cljc
+++ b/src/atproto/xrpc/frames.cljc
@@ -1,0 +1,121 @@
+(ns atproto.xrpc.frames
+  "Binary event-stream frames: a dag-CBOR header item followed by a
+  dag-CBOR body item.
+
+  A frame is exactly two concatenated DAG-CBOR items:
+  - message frame: header {:op 1, :t \"#commit\"} (:t optional), any body
+  - error frame:   header {:op -1}, body {:error name :message msg?}
+
+  This is the canonical frame codec for the SDK (overview §4.7); the
+  firehose client (WS-05) and stream server (WS-11C) both consume it.
+  Pure and synchronous; mirrors packages/xrpc-server/src/stream/frames.ts
+  in the reference implementation."
+  (:require [clojure.string :as str]
+            [atproto.data.cbor :as cbor]
+            [atproto.runtime.bytes :as bytes]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def message-op 1)
+(def error-op -1)
+
+(defn message-frame
+  "Frame for a message body.
+
+  The body's :$type (if any) is moved to the header :t, compressed to
+  \"#frag\" when its nsid is empty or equals `nsid` (reference
+  MessageFrame.fromLexValue). Returns {:op 1 :body ... & :t}."
+  [body & {:keys [nsid]}]
+  (let [$type (when (map? body) (:$type body))]
+    (if (not (string? $type))
+      {:op message-op :body body}
+      (let [[type-nsid frag :as split] (str/split $type #"#" -1)
+            t (if (and (= 2 (count split))
+                       (or (= "" type-nsid) (= nsid type-nsid)))
+                (str "#" frag)
+                $type)]
+        {:op message-op :t t :body (dissoc body :$type)}))))
+
+(defn error-frame
+  "Frame carrying {:error name :message msg?}; header {:op -1}."
+  [error & [message]]
+  {:op error-op
+   :body (cond-> {:error error}
+           (some? message) (assoc :message message))})
+
+(defn- frame-header
+  "The dag-CBOR header item for a frame map, or nil if the frame is invalid."
+  [{:keys [op t]}]
+  (cond
+    (= op message-op) (cond-> {:op message-op}
+                        (some? t) (assoc :t t))
+    (= op error-op)   {:op error-op}))
+
+(defn encode
+  "Frame map -> bytes (header item ++ body item).
+  Throws ex-info for a frame with an invalid :op."
+  [{:keys [op body] :as frame}]
+  (if-let [header (frame-header frame)]
+    (let [^bytes h (cbor/encode header)
+          ^bytes b (cbor/encode body)]
+      #?(:clj (let [out (byte-array (+ (alength h) (alength b)))]
+                (System/arraycopy h 0 out 0 (alength h))
+                (System/arraycopy b 0 out (alength h) (alength b))
+                out)
+         :cljs (let [out (js/Uint8Array. (+ (.-length h) (.-length b)))]
+                 (.set out h 0)
+                 (.set out b (.-length h))
+                 out)))
+    (throw (ex-info "Invalid frame op."
+                    {:error "InvalidFrame"
+                     :message (str "Invalid frame op: " (pr-str op))}))))
+
+(defn- invalid-frame
+  [message]
+  {:error "InvalidFrame" :message message})
+
+(defn- valid-header?
+  [header]
+  (and (map? header)
+       (or (and (= message-op (:op header))
+                (or (not (contains? header :t))
+                    (string? (:t header))))
+           (= error-op (:op header)))))
+
+(defn- valid-error-body?
+  [body]
+  (and (map? body)
+       (string? (:error body))
+       (or (not (contains? body :message))
+           (string? (:message body)))))
+
+(defn decode
+  "bytes -> {:op 1 :t \"#x\" :body {...}} | {:op -1 :body {:error ...}}
+  or {:error \"InvalidFrame\" :message ...} for a missing body, more than
+  two CBOR items, an invalid header, or an invalid error-frame body."
+  [bytes]
+  (let [items (try
+                (cbor/decode-multi bytes)
+                (catch #?(:clj Exception :cljs :default) e
+                  (invalid-frame (str "Invalid frame CBOR: " (ex-message e)))))]
+    (if (:error items)
+      items
+      (let [[header body] items]
+        (cond
+          (< 2 (count items))
+          (invalid-frame "Too many CBOR data items in frame.")
+
+          (< (count items) 2)
+          (invalid-frame "Missing frame body.")
+
+          (not (valid-header? header))
+          (invalid-frame (str "Invalid frame header: " (pr-str header)))
+
+          (= message-op (:op header))
+          (cond-> {:op message-op :body body}
+            (contains? header :t) (assoc :t (:t header)))
+
+          :else
+          (if (valid-error-body? body)
+            {:op error-op :body body}
+            (invalid-frame (str "Invalid error frame body: " (pr-str body)))))))))

--- a/src/atproto/xrpc/rate_limit.cljc
+++ b/src/atproto/xrpc/rate_limit.cljc
@@ -1,0 +1,128 @@
+(ns atproto.xrpc.rate-limit
+  "Rate-limit hook points for the XRPC server (interface only).
+
+  Ports the reference RateLimiterI interface and its combinators
+  (packages/xrpc-server/src/rate-limiter.ts): a limiter consumes points
+  for a key computed from the request context, and reports either nil
+  (skipped / not applicable), a status map, or a RateLimitExceeded error.
+
+  Status map shape:
+  {:limit n             ;; points per window
+   :duration secs       ;; window duration in seconds
+   :remaining-points n
+   :ms-before-next ms   ;; ms until the window resets
+   :consumed-points n}
+
+  Key/point computation:
+  :calc-key    (fn [ctx]) -> string | nil   (nil skips the limiter)
+  :calc-points (fn [ctx]) -> int            (< 1 skips the limiter)
+  where ctx is the same map auth verifiers receive plus :auth. Wrapped
+  limiters override these per call site via ::calc-key / ::calc-points
+  on the ctx, which limiter implementations must honor.
+
+  No production limiter is shipped; `memory` is for tests/dev only."
+  (:refer-clojure :exclude [reset]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defprotocol RateLimiter
+  (consume [limiter ctx cb]
+    "Consume points for this request context.
+     cb receives nil (skipped), a status map (not limited), or
+     {:error \"RateLimitExceeded\" :status 429 :ratelimit-status <status>}.")
+  (reset [limiter ctx cb]
+    "Reset the counter for this request context's key. cb receives nil."))
+
+(defn wrapped
+  "Override the :calc-key / :calc-points of a limiter."
+  [limiter {:keys [calc-key calc-points]}]
+  (let [override #(cond-> %
+                    calc-key (assoc ::calc-key calc-key)
+                    calc-points (assoc ::calc-points calc-points))]
+    (reify RateLimiter
+      (consume [_ ctx cb] (consume limiter (override ctx) cb))
+      (reset [_ ctx cb] (reset limiter (override ctx) cb)))))
+
+(defn- tighter
+  [a b]
+  (cond
+    (nil? a) b
+    (nil? b) a
+    (< (:remaining-points b) (:remaining-points a)) b
+    :else a))
+
+(defn combined
+  "Combine limiters; all are consumed and the tightest (lowest remaining
+  points) status wins. Any exceeded/error result short-circuits."
+  [limiters]
+  (reify RateLimiter
+    (consume [_ ctx cb]
+      (letfn [(step [remaining tightest]
+                (if (empty? remaining)
+                  (cb tightest)
+                  (consume (first remaining) ctx
+                           (fn [result]
+                             (if (:error result)
+                               (cb result)
+                               (step (rest remaining) (tighter tightest result)))))))]
+        (step (seq limiters) nil)))
+    (reset [_ ctx cb]
+      (letfn [(step [remaining]
+                (if (empty? remaining)
+                  (cb nil)
+                  (reset (first remaining) ctx (fn [_] (step (rest remaining))))))]
+        (step (seq limiters))))))
+
+(defn- now-ms
+  []
+  #?(:clj (System/currentTimeMillis)
+     :cljs (.now js/Date)))
+
+(defn memory
+  "Trivial in-memory fixed-window limiter (tests/dev only).
+
+  config:
+  :key-prefix   namespace for keys (limiters sharing an atom must differ).
+  :duration-ms  window length in milliseconds.
+  :points       max points per window.
+  :calc-key     (fn [ctx]) -> string | nil; default: the request :ip.
+  :calc-points  (fn [ctx]) -> int; default: 1."
+  [{:keys [key-prefix duration-ms points calc-key calc-points]}]
+  (let [state (atom {})
+        default-calc-key (or calc-key (fn [ctx] (get-in ctx [:request :ip])))
+        default-calc-points (or calc-points (constantly 1))
+        entry-key (fn [ctx]
+                    (when-let [k ((or (::calc-key ctx) default-calc-key) ctx)]
+                      (str key-prefix ":" k)))]
+    (reify RateLimiter
+      (consume [_ ctx cb]
+        (let [k (entry-key ctx)
+              pts ((or (::calc-points ctx) default-calc-points) ctx)]
+          (if (or (nil? k) (< pts 1))
+            (cb nil)
+            (let [now (now-ms)
+                  [_ next-state]
+                  (swap-vals! state
+                              (fn [m]
+                                (let [{:keys [consumed resets-at]} (get m k)]
+                                  (if (or (nil? resets-at) (<= resets-at now))
+                                    (assoc m k {:consumed pts
+                                                :resets-at (+ now duration-ms)})
+                                    (assoc m k {:consumed (+ consumed pts)
+                                                :resets-at resets-at})))))
+                  {:keys [consumed resets-at]} (get next-state k)
+                  status {:limit points
+                          :duration (quot duration-ms 1000)
+                          :remaining-points (max 0 (- points consumed))
+                          :ms-before-next (max 0 (- resets-at now))
+                          :consumed-points consumed}]
+              (if (< points consumed)
+                (cb {:error "RateLimitExceeded"
+                     :message "Rate Limit Exceeded"
+                     :status 429
+                     :ratelimit-status status})
+                (cb status))))))
+      (reset [_ ctx cb]
+        (when-let [k (entry-key ctx)]
+          (swap! state dissoc k))
+        (cb nil)))))

--- a/src/atproto/xrpc/server.cljc
+++ b/src/atproto/xrpc/server.cljc
@@ -1,25 +1,107 @@
 (ns atproto.xrpc.server
-  "Functions to implement atproto HTTP services."
-  (:require [clojure.string :as str]
+  "Functions to implement atproto HTTP services.
+
+  Request pipeline (reference parity, packages/xrpc-server/src/server.ts):
+  parse/validate params -> authenticate -> validate input -> rate-limit ->
+  handle -> validate output. Auth failures fire before input validation."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [clojure.spec.alpha :as s]
-            [clojure.walk :refer [stringify-keys]]
             [atproto.runtime.interceptor :as i]
             [atproto.runtime.http :as http]
             [atproto.runtime.json :as json]
             [atproto.runtime.cast :as cast]
+            [atproto.runtime.crypto :as runtime-crypto]
             [atproto.data.json :as atproto-json]
-            [atproto.lexicon :as lexicon]))
+            [atproto.lexicon :as lexicon]
+            [atproto.service-auth :as service-auth]
+            [atproto.xrpc.rate-limit :as rate-limit]))
+
+#?(:clj (set! *warn-on-reflection* true))
 
 (defn init
-  [{:keys [lexicon validate-response?] :as config}]
+  "Initialize the XRPC server.
+
+  config:
+  :lexicon            (required) the Lexicon to serve.
+  :validate-response? validate handler responses against the lexicon.
+  :auth               map of nsid (string) -> auth verifier fn, plus an
+                      optional :default entry applied to routes without a
+                      specific entry. Routes absent from the map (and no
+                      :default) are unauthenticated. A verifier is async,
+                      callback style: (fn [ctx cb]) where ctx is
+                      {:nsid ... :params ... :request ... :app-ctx ...}
+                      and cb receives {:credentials ... & anything} on
+                      success or {:error ... :message ... :status 401/403}
+                      on failure.
+  :rate-limit         {:global [limiter ...]          ;; RateLimiter instances
+                       :routes {nsid [limiter ...]}}  ;; per-route"
+  [{:keys [lexicon validate-response? auth rate-limit] :as config}]
   (lexicon/register-specs! lexicon)
   config)
+
+;; -----------------------------------------------------------------------------
+;; Error helpers
+;; -----------------------------------------------------------------------------
+;; Status table per the reference ResponseType enum (packages/xrpc/src/types.ts).
+;; Handlers may also return {:error "CustomName" :status n :message ...} to
+;; surface lexicon-defined error names; an :error without :status maps to a
+;; generic 500.
 
 (defn invalid-request
   [message]
   {:status 400
    :error "InvalidRequest"
    :message message})
+
+(defn auth-required
+  ([] (auth-required "Authentication Required"))
+  ([message]
+   {:status 401
+    :error "AuthenticationRequired"
+    :message message}))
+
+(defn forbidden
+  ([] (forbidden "Forbidden"))
+  ([message]
+   {:status 403
+    :error "Forbidden"
+    :message message}))
+
+(defn xrpc-not-supported
+  []
+  {:status 404
+   :error "XRPCNotSupported"
+   :message "XRPC Not Supported"})
+
+(defn not-acceptable
+  ([] (not-acceptable "Not Acceptable"))
+  ([message]
+   {:status 406
+    :error "NotAcceptable"
+    :message message}))
+
+(defn payload-too-large
+  ([] (payload-too-large "Payload Too Large"))
+  ([message]
+   {:status 413
+    :error "PayloadTooLarge"
+    :message message}))
+
+(defn unsupported-media-type
+  ([] (unsupported-media-type "Unsupported Media Type"))
+  ([message]
+   {:status 415
+    :error "UnsupportedMediaType"
+    :message message}))
+
+(defn rate-limit-exceeded
+  ([] (rate-limit-exceeded nil))
+  ([ratelimit-status]
+   (cond-> {:status 429
+            :error "RateLimitExceeded"
+            :message "Rate Limit Exceeded"}
+     ratelimit-status (assoc :ratelimit-status ratelimit-status))))
 
 (defn invalid-response
   [message]
@@ -39,11 +121,34 @@
    :error "MethodNotImplemented"
    :message "Method Not Implemented"})
 
-(defn auth-required
+(defn upstream-failure
   []
-  {:status 401
-   :error "AuthenticationRequired"
-   :message "Authentication Required"})
+  {:status 502
+   :error "UpstreamFailure"
+   :message "Upstream Failure"})
+
+(defn not-enough-resources
+  []
+  {:status 503
+   :error "NotEnoughResources"
+   :message "Not Enough Resources"})
+
+(defn upstream-timeout
+  []
+  {:status 504
+   :error "UpstreamTimeout"
+   :message "Upstream Timeout"})
+
+(def ^:private generic-5xx-messages
+  {500 "Internal Server Error"
+   501 "Method Not Implemented"
+   502 "Upstream Failure"
+   503 "Not Enough Resources"
+   504 "Upstream Timeout"})
+
+;; -----------------------------------------------------------------------------
+;; HTTP request parsing
+;; -----------------------------------------------------------------------------
 
 (defn decode-query-param
   "Decode a query string parameter based on the type definition."
@@ -54,11 +159,12 @@
                 "false" false
                 val)
     "integer" (if (re-matches #"^-?[0-9]+$" val)
-                (clojure.edn/read-string val)
+                (edn/read-string val)
                 val)
     "string"  val
     "unknown" val
-    "array"   (mapv #(decode-query-param (:items type-def) %) val)))
+    "array"   (mapv #(decode-query-param (:items type-def) %)
+                    (if (coll? val) val [val]))))
 
 (defn- query-params->xrpc-params
   "Parse the HTTP query parameters according to the Lexicon definition."
@@ -73,34 +179,59 @@
 
               :else
               query-params))
-          query-params
+          (or query-params {})
           properties))
 
+(defn url-nsid
+  "The syntactically valid NSID from an /xrpc/<nsid> URL, or nil for a
+  malformed XRPC path."
+  [url]
+  (when-let [path (:path (http/parse-url url))]
+    (when (str/starts-with? path "/xrpc/")
+      (let [nsid (subs path (count "/xrpc/"))]
+        (when (s/valid? ::lexicon/nsid nsid)
+          nsid)))))
+
 (defn http-request->xrpc-request
-  "Validate the HTTP request and return the NSID if valid and found in the lexicon."
+  "Parse and validate the HTTP request envelope against the lexicon.
+
+  Returns the xrpc-request, or an error map: malformed /xrpc/ path -> 400,
+  valid-but-unknown NSID -> 501 (reference catchall), wrong HTTP verb -> 400."
   [lexicon {:keys [method url query-params headers body]}]
-  (let [nsid (subs (:path (http/parse-url url))
-                   (count "/xrpc/"))
-        type-def (lexicon/type-def lexicon nsid)]
-    (if (not type-def)
-      (invalid-request "Unknown NSID")
+  (let [nsid (url-nsid url)
+        type-def (when nsid (lexicon/type-def lexicon nsid))]
+    (cond
+      (nil? nsid)
+      (invalid-request "Invalid XRPC path.")
+
+      (nil? type-def)
+      (method-not-implemented)
+
+      :else
       (let [{:keys [type parameters input]} type-def
             expected-method (case type
                               "procedure"    :post
                               "query"        :get
                               "subscription" :get)]
-        (if (not (= expected-method method))
+        (cond
+          (not= expected-method method)
           (invalid-request "Incorrect HTTP method")
-          (if (and (some? body) (not (:content-type headers)))
-            (invalid-request "Missing encoding")
-            (cond-> {:nsid nsid}
-              (some? parameters)
-              (assoc :params (query-params->xrpc-params parameters
-                                                        query-params))
 
-              (some? input)
-              (assoc :encoding (:content-type headers)
-                     :body body))))))))
+          (and (some? body) (not (:content-type headers)))
+          (invalid-request "Missing encoding")
+
+          :else
+          (cond-> {:nsid nsid}
+            (some? parameters)
+            (assoc :params (query-params->xrpc-params parameters query-params))
+
+            (some? input)
+            (assoc :encoding (:content-type headers)
+                   :body body)))))))
+
+;; -----------------------------------------------------------------------------
+;; Handlers
+;; -----------------------------------------------------------------------------
 
 (defmulti handle
   "Handle the XRPC request.
@@ -110,52 +241,302 @@
   :params    The query parameters as a map
   :body      The input for procedures. `::atproto/data` or `bytes`
   :encoding  The encoding of the body (`application/json` for `::atproto/data`)
+  :auth      The route's auth verifier success map (when configured),
+             e.g. {:credentials ...}
 
   The function must return a map with:
   :body      The response body: `::atproto/data` or `bytes`.
-  :encoding  The encoding of the body (`application/json` for `::atproto/data`)"
+  :encoding  The encoding of the body (`application/json` for `::atproto/data`)
+  or an error map (:error/:message and optional :status)."
   (fn [app-ctx request] (:nsid request)))
 
 (defmethod handle :default [_ _] (method-not-implemented))
 
+(defmulti handle-subscription
+  "Handle a subscription (websocket) request for an NSID.
+
+  Takes [app-ctx request] where request has :nsid, :params, :auth, and
+  (once the transport is connected) :close-ch — a core.async channel that
+  is closed when the client disconnects, so producers can stop.
+
+  Must return a map:
+    {:messages ch}    core.async channel of outgoing messages. Each item
+                      is either atproto data (maps; :$type is lifted into
+                      the frame header) or {:frame/error \"Name\"
+                      :frame/message \"...\"} to emit an error frame and
+                      close with ws code 1008. Closing the channel closes
+                      the socket normally (1000).
+  or {:error ...} to reject the subscription."
+  (fn [app-ctx request] (:nsid request)))
+
+(defmethod handle-subscription :default [_ _] (method-not-implemented))
+
+;; -----------------------------------------------------------------------------
+;; Auth
+;; -----------------------------------------------------------------------------
+
+(defn- auth-verifier-for
+  [auth nsid]
+  (when auth
+    (or (get auth nsid)
+        (:default auth))))
+
+(defn- with-401
+  [error-map]
+  (cond-> error-map
+    (not (:status error-map)) (assoc :status 401)))
+
+(defn- run-auth
+  "Run the route's auth verifier, if any. cb receives nil (no verifier),
+  the verifier's success map, or an error map (401 default status)."
+  [verifier verifier-ctx cb]
+  (if (not verifier)
+    (cb nil)
+    (try
+      (verifier verifier-ctx
+                (fn [{:keys [error] :as result}]
+                  (cb (cond-> result error with-401))))
+      (catch #?(:clj Throwable :cljs :default) t
+        (cast/alert {:message "Error in auth verifier" :ex t})
+        (cb (auth-required))))))
+
+(defn service-auth-verifier
+  "Ready-made auth verifier for inter-service JWTs.
+
+  config:
+  :own-did          this service's DID (audience check; nil to skip).
+  :allowed-issuers  optional issuer allow-list.
+  :get-signing-key  optional override; defaults to
+                    (service-auth/did-signing-key-resolver config).
+
+  Extracts the Bearer token ({:error \"MissingJwt\" :status 401} when
+  absent), verifies it with :lxm bound to the route nsid, and yields
+  {:credentials {:type :service :did <iss-did> :iss <full-iss>
+                 :payload <claims>}}."
+  [{:keys [own-did get-signing-key] :as config}]
+  (let [get-signing-key (or get-signing-key
+                            (service-auth/did-signing-key-resolver config))]
+    (fn [{:keys [nsid request]} cb]
+      (let [authorization (get-in request [:headers :authorization])]
+        (if (not (and (string? authorization)
+                      (str/starts-with? authorization "Bearer ")))
+          (cb {:error "MissingJwt" :message "missing jwt" :status 401})
+          (service-auth/verify-jwt
+           (subs authorization (count "Bearer "))
+           {:aud own-did
+            :lxm nsid
+            :get-signing-key get-signing-key}
+           :callback
+           (fn [{:keys [error iss] :as resp}]
+             (cb (if error
+                   resp
+                   {:credentials {:type :service
+                                  :did (first (str/split iss #"#" 2))
+                                  :iss iss
+                                  :payload resp}})))))))))
+
+;; -----------------------------------------------------------------------------
+;; Request validation (params before auth, input after)
+;; -----------------------------------------------------------------------------
+
+(defn- request-spec
+  [nsid]
+  (binding [lexicon/*schema-validate* true]
+    (lexicon/request-spec-key nsid)))
+
+(defn- input-problem?
+  "True when this spec problem concerns the request input (:body/:encoding)
+  rather than its params; input problems are reported only after auth."
+  [{:keys [path in pred]}]
+  (let [k (or (first in) (first path))]
+    (or (#{:body :encoding} k)
+        ;; a missing :body/:encoding key: pred is (fn [%] (contains? % :body))
+        (and (nil? k)
+             (coll? pred)
+             (boolean (some #{:body :encoding}
+                            (filter keyword? (tree-seq coll? seq pred))))))))
+
+;; -----------------------------------------------------------------------------
+;; Rate limiting
+;; -----------------------------------------------------------------------------
+
+(defn- route-limiters
+  [{:keys [global routes]} nsid]
+  (concat global (get routes nsid)))
+
+(defn- consume-limiters
+  "Consume limiters in order; cb receives the tightest status map (or nil),
+  or the first {:error ...}."
+  [limiters limiter-ctx cb]
+  (letfn [(step [remaining tightest]
+            (if (empty? remaining)
+              (cb tightest)
+              (rate-limit/consume
+               (first remaining) limiter-ctx
+               (fn [result]
+                 (cond
+                   (:error result) (cb result)
+                   (nil? result)   (step (rest remaining) tightest)
+                   :else (step (rest remaining)
+                               (if (or (nil? tightest)
+                                       (< (:remaining-points result)
+                                          (:remaining-points tightest)))
+                                 result
+                                 tightest)))))))]
+    (step (seq limiters) nil)))
+
+(defn- ratelimit-headers
+  "RateLimit-* response headers for a limiter status map (reference
+  rate-limiter-http.ts setResHeaders)."
+  [{:keys [limit duration remaining-points ms-before-next] :as status}]
+  (when status
+    {:ratelimit-limit (str limit)
+     :ratelimit-remaining (str remaining-points)
+     :ratelimit-reset (str (+ (runtime-crypto/now)
+                              (quot (or ms-before-next 0) 1000)))
+     :ratelimit-policy (str limit ";w=" duration)}))
+
+;; -----------------------------------------------------------------------------
+;; Pipeline
+;; -----------------------------------------------------------------------------
+
+(defn- run-handle
+  "Invoke the handle multimethod, mapping thrown exceptions to a 500."
+  [app-ctx xrpc-request]
+  (try
+    (handle app-ctx xrpc-request)
+    (catch #?(:clj Throwable :cljs :default) t
+      (cast/alert {:message "Error in XRPC handler" :ex t})
+      (internal-server-error))))
+
+(defn- validate-response
+  [{:keys [validate-response?]} nsid xrpc-response]
+  (let [spec-key (binding [lexicon/*schema-validate* (boolean validate-response?)]
+                   (lexicon/response-spec-key nsid))]
+    (if (s/valid? spec-key xrpc-response)
+      xrpc-response
+      (invalid-response (s/explain-str spec-key xrpc-response)))))
+
+(defn- process-request
+  "Run the pipeline for a parsed xrpc-request; respond receives the
+  xrpc-response (success or error map, possibly with :ratelimit-status)."
+  [{:keys [auth rate-limit] :as server} http-request xrpc-request respond]
+  (let [{:keys [nsid]} xrpc-request
+        spec (request-spec nsid)
+        problems (::s/problems (s/explain-data spec xrpc-request))
+        verifier-ctx {:nsid nsid
+                      :params (:params xrpc-request)
+                      :request http-request
+                      :app-ctx (:app-ctx http-request)}]
+    (if (seq (remove input-problem? problems))
+      (respond (invalid-request (s/explain-str spec xrpc-request)))
+      (run-auth
+       (auth-verifier-for auth nsid) verifier-ctx
+       (fn [{:keys [error] :as auth-result}]
+         (cond
+           error
+           (respond auth-result)
+
+           (seq problems)
+           (respond (invalid-request (s/explain-str spec xrpc-request)))
+
+           :else
+           (consume-limiters
+            (route-limiters rate-limit nsid)
+            (cond-> verifier-ctx auth-result (assoc :auth auth-result))
+            (fn [{:keys [error] :as limit-result}]
+              (if error
+                (respond limit-result)
+                (let [xrpc-request (cond-> xrpc-request
+                                     auth-result (assoc :auth auth-result))
+                      xrpc-response (run-handle (:app-ctx http-request) xrpc-request)]
+                  (respond
+                   (cond-> (if (:error xrpc-response)
+                             xrpc-response
+                             (validate-response server nsid xrpc-response))
+                     limit-result (assoc :ratelimit-status limit-result)))))))))))))
+
 (defn interceptor
-  "Handle HTTP requests and delegate execution to a `handle` method after parsing/validation."
-  [{:keys [lexicon validate-response?]}]
+  "Handle HTTP requests and delegate execution to a `handle` method after
+  parsing/validation. Auth and rate-limit hooks are async; the enter fn
+  continues the chain via i/continue from their callbacks."
+  [{:keys [lexicon] :as server}]
   {::i/name ::interceptor
    ::i/enter (fn [{:keys [::i/request] :as ctx}]
-               (assoc ctx
-                      ::i/response
-                      (let [xrpc-request (http-request->xrpc-request lexicon request)]
-                        (if (:error xrpc-request)
-                          xrpc-request
-                          (let [spec-key (binding [lexicon/*schema-validate* true]
-                                           (lexicon/request-spec-key (:nsid xrpc-request)))]
-                            (if (not (s/valid? spec-key xrpc-request))
-                              (invalid-request (s/explain-str spec-key xrpc-request))
-                              (let [xrpc-response (handle (:app-ctx request) xrpc-request)]
-                                (if (:error xrpc-response)
-                                  xrpc-response
-                                  (let [spec-key (binding [lexicon/*schema-validate* validate-response?]
-                                                   (lexicon/response-spec-key (:nsid xrpc-request)))]
-                                    (if (not (s/valid? spec-key xrpc-response))
-                                      (invalid-response (s/explain-str spec-key xrpc-response))
-                                      xrpc-response))))))))))
+               (let [respond #(i/continue (assoc ctx ::i/response %))
+                     xrpc-request (http-request->xrpc-request lexicon request)]
+                 (if (:error xrpc-request)
+                   (respond xrpc-request)
+                   (process-request server request xrpc-request respond))
+                 nil))
    ::i/leave (fn [ctx]
                (update ctx
                        ::i/response
-                       (fn [{:keys [error status message encoding body] :as xrpc-response}]
-                         (if error
-                           (do
-                             (cast/alert xrpc-response)
-                             (if (not status)
-                               (internal-server-error)
-                               {:status status
-                                :headers {:content-type "application/json"}
-                                :body (cond-> {:error error}
-                                        (some? message) (assoc :message message))}))
-                           {:status 200
-                            :headers {:content-type encoding}
-                            :body body}))))})
+                       (fn [{:keys [error status message encoding body ratelimit-status]
+                             :as xrpc-response}]
+                         (let [rl-headers (ratelimit-headers ratelimit-status)]
+                           (if error
+                             (do
+                               (cast/alert (dissoc xrpc-response :ratelimit-status))
+                               (let [{:keys [status] :as sanitized}
+                                     (cond
+                                       (not status) (internal-server-error)
+                                       ;; 5xx messages never leak internals
+                                       (<= 500 status)
+                                       (assoc xrpc-response
+                                              :message (get generic-5xx-messages
+                                                            status
+                                                            "Internal Server Error"))
+                                       :else xrpc-response)]
+                                 {:status status
+                                  :headers (merge {:content-type "application/json"}
+                                                  rl-headers)
+                                  :body (cond-> {:error (:error sanitized)}
+                                          (some? (:message sanitized))
+                                          (assoc :message (:message sanitized)))}))
+                             {:status 200
+                              :headers (merge {:content-type encoding} rl-headers)
+                              :body body})))))})
+
+(defn subscription-request
+  "Validate an HTTP (upgrade) request against the lexicon and run the
+  route's auth verifier. Async; yields the xrpc-request for
+  handle-subscription, or {:error ...}. Shared by transport adapters."
+  [{:keys [lexicon auth] :as server} http-request & {:as opts}]
+  (let [[cb val] (i/platform-async (select-keys opts [:channel :callback :promise]))
+        nsid (url-nsid (:url http-request))
+        type-def (when nsid (lexicon/type-def lexicon nsid))]
+    (cond
+      (nil? nsid)
+      (cb (invalid-request "Invalid XRPC path."))
+
+      (nil? type-def)
+      (cb (method-not-implemented))
+
+      (not= "subscription" (:type type-def))
+      (cb (invalid-request "Not a subscription endpoint."))
+
+      :else
+      (let [{:keys [parameters]} type-def
+            xrpc-request (cond-> {:nsid nsid}
+                           (some? parameters)
+                           (assoc :params (query-params->xrpc-params
+                                           parameters
+                                           (:query-params http-request))))
+            spec (request-spec nsid)]
+        (if (not (s/valid? spec xrpc-request))
+          (cb (invalid-request (s/explain-str spec xrpc-request)))
+          (run-auth (auth-verifier-for auth nsid)
+                    {:nsid nsid
+                     :params (:params xrpc-request)
+                     :request http-request
+                     :app-ctx (:app-ctx http-request)}
+                    (fn [{:keys [error] :as auth-result}]
+                      (cb (cond
+                            error auth-result
+                            auth-result (assoc xrpc-request :auth auth-result)
+                            :else xrpc-request)))))))
+    val))
 
 (defn handle-http-request
   "Handle an HTTP request and delegate execution to the API implementation.
@@ -165,4 +546,5 @@
   (i/execute {::i/request http-request
               ::i/queue [json/server-interceptor
                          atproto-json/server-interceptor
-                         (interceptor server)]}))
+                         (interceptor server)]}
+             opts))

--- a/src/atproto/xrpc/server/ring.clj
+++ b/src/atproto/xrpc/server/ring.clj
@@ -1,20 +1,42 @@
 (ns atproto.xrpc.server.ring
+  "Ring adapter for the XRPC server, including the http-kit websocket
+  transport for lexicon `subscription` endpoints.
+
+  Subscription semantics (reference packages/xrpc-server/src/stream/server.ts):
+  outgoing messages are sent as binary frames; an error (subscription
+  rejection or a {:frame/error ...} item) is sent as an error frame and the
+  socket is closed with ws code 1008 (Policy); normal completion closes
+  with 1000. Two http-kit transport limitations (the error name still
+  reaches clients in the error frame body, which is the atproto spec's
+  mechanism):
+  - the close frame carries no reason string: AsyncChannel.serverClose
+    encodes only the 2-byte status code, unlike the reference which sets
+    the error name as the close reason;
+  - backpressure is best-effort (no per-send completion callback): use a
+    bounded :messages channel for producer-side backpressure."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.walk :refer [keywordize-keys stringify-keys]]
+            [clojure.core.async :as async]
+            [org.httpkit.server :as httpkit]
             [atproto.runtime.http :as http]
+            [atproto.runtime.json :as json]
             [atproto.runtime.cast :as cast]
+            [atproto.lexicon :as lexicon]
+            [atproto.xrpc.frames :as frames]
             [atproto.xrpc.server :as xrpc-server])
-  (:import [java.io ByteArrayOutputStream]))
+  (:import [java.io ByteArrayOutputStream]
+           [org.httpkit.server AsyncChannel]))
 
 (set! *warn-on-reflection* true)
 
 (defn input-stream->bytes ^bytes [is]
-  (let [os (ByteArrayOutputStream.)]
-    (io/copy is os)
-    (let [ba (.toByteArray os)]
-      (when (not (zero? (count ba)))
-        ba))))
+  (when is
+    (let [os (ByteArrayOutputStream.)]
+      (io/copy is os)
+      (let [ba (.toByteArray os)]
+        (when (not (zero? (count ba)))
+          ba)))))
 
 (defn ring-request->http-request
   [{:keys [request-method scheme server-name server-port uri query-string headers body app-ctx]}]
@@ -34,10 +56,94 @@
   [http-response]
   (update http-response :headers stringify-keys))
 
+;; -----------------------------------------------------------------------------
+;; Websocket subscription transport
+;; -----------------------------------------------------------------------------
+
+(def ^:private close-normal 1000)
+(def ^:private close-policy 1008)
+
+(defn- ws-close!
+  "Close the websocket with the given close code (http-kit cannot attach a
+  close reason; see the namespace docstring)."
+  [ch code]
+  (.serverClose ^AsyncChannel ch (int code)))
+
+(defn- send-error-frame!
+  "Send an error frame, then close with 1008/Policy."
+  [ch {:keys [error message]}]
+  (httpkit/send! ch (frames/encode (frames/error-frame error message)) false)
+  (ws-close! ch close-policy))
+
+(defn- run-send-loop
+  "Drive the frame send loop for an accepted subscription."
+  [ch nsid messages]
+  (async/go-loop []
+    (if-some [msg (async/<! messages)]
+      (if (:frame/error msg)
+        (send-error-frame! ch {:error (:frame/error msg)
+                               :message (:frame/message msg)})
+        (if (httpkit/send! ch (frames/encode (frames/message-frame msg :nsid nsid)) false)
+          (recur)
+          ;; client went away; the :close-ch signal lets the producer stop
+          nil))
+      (ws-close! ch close-normal))))
+
+(defn- xrpc-error-ring-response
+  "A plain HTTP (non-upgraded) JSON response for an XRPC error map."
+  [{:keys [status error message]}]
+  {:status (or status 500)
+   :headers {"content-type" "application/json"}
+   :body (json/write-str (cond-> {:error error}
+                           (some? message) (assoc :message message)))})
+
+(defn- subscription-ring-response
+  "Handle a request for a lexicon subscription NSID.
+
+  Validates the request and runs the route's auth verifier
+  (xrpc-server/subscription-request), then invokes handle-subscription and
+  drives the frame send loop over the websocket. Errors after the upgrade
+  are reported as an error frame followed by close 1008 (reference
+  behavior); non-websocket requests get the mapped XRPC error JSON."
+  [server {:keys [app-ctx websocket?] :as ring-request}]
+  (let [http-request (ring-request->http-request ring-request)
+        result @(xrpc-server/subscription-request server http-request)
+        close-ch (async/chan)
+        sub (when (not (:error result))
+              (xrpc-server/handle-subscription app-ctx (assoc result :close-ch close-ch)))
+        error (or (when (:error result) result)
+                  (when (:error sub) sub))]
+    (if (not websocket?)
+      (xrpc-error-ring-response (or error (xrpc-server/invalid-request
+                                           "Expected a WebSocket upgrade request.")))
+      (httpkit/as-channel
+       ring-request
+       {:on-open (fn [ch]
+                   (cast/event {:message "XRPC subscription opened"
+                                :nsid (:nsid result)
+                                :error (:error error)})
+                   (if error
+                     (send-error-frame! ch error)
+                     (run-send-loop ch (:nsid result) (:messages sub))))
+        :on-close (fn [_ch status]
+                    (cast/event {:message "XRPC subscription closed"
+                                 :nsid (:nsid result)
+                                 :status status})
+                    (async/close! close-ch))}))))
+
+(defn- subscription-nsid
+  "The NSID of the lexicon subscription this request targets, if any."
+  [{:keys [lexicon]} uri]
+  (let [nsid (subs uri (count "/xrpc/"))]
+    (when (= "subscription" (:type (lexicon/type-def lexicon nsid)))
+      nsid)))
+
 (defn handler
   [server]
   (fn [ring-request]
     (when (str/starts-with? (:uri ring-request) "/xrpc/")
-      (http-response->ring-response
-       @(xrpc-server/handle-http-request server
-                                         (ring-request->http-request ring-request))))))
+      (if (subscription-nsid server (:uri ring-request))
+        (subscription-ring-response server ring-request)
+        (http-response->ring-response
+         @(xrpc-server/handle-http-request server
+                                           (ring-request->http-request ring-request)))))))

--- a/test/atproto/service_auth/generate_fixtures.mjs
+++ b/test/atproto/service_auth/generate_fixtures.mjs
@@ -1,0 +1,73 @@
+// Generates jwt_fixtures.json from the TypeScript reference implementation.
+//
+// Usage:
+//   npm install @atproto/xrpc-server@0.11.1 @atproto/crypto@0.5.0
+//   node generate_fixtures.mjs > jwt_fixtures.json
+//
+// Tokens are minted with createServiceJwt from @atproto/xrpc-server
+// (packages/xrpc-server/src/auth.ts). ECDSA signing in the reference is
+// deterministic (RFC 6979 via @noble/curves), but each token embeds a
+// freshly generated random `jti`, so regenerated files differ in jti and
+// signature; the committed output is what the Clojure tests consume.
+import { createServiceJwt, verifyJwt } from '@atproto/xrpc-server'
+import { Secp256k1Keypair, P256Keypair } from '@atproto/crypto'
+
+const ISS = 'did:example:alice'
+const AUD = 'did:example:bob'
+const LXM = 'com.atproto.repo.createRecord'
+const IAT = 1750000000
+const EXP = 32503680000 // 3000-01-01, keeps verification tests green
+const PAST_EXP = 1750000060
+
+const keys = {
+  ES256K: {
+    privHex: '0000000000000000000000000000000000000000000000000000000000000001',
+    make: (hex) => Secp256k1Keypair.import(hex),
+  },
+  ES256: {
+    privHex: '0000000000000000000000000000000000000000000000000000000000000002',
+    make: (hex) => P256Keypair.import(hex),
+  },
+}
+
+const fixtures = {
+  _meta: {
+    description:
+      'Service JWTs minted by the TypeScript reference implementation for cross-implementation verification.',
+    repository: 'https://github.com/bluesky-social/atproto',
+    commit: '3e977fe0ab88145f4ff26b491f371d3bade22505',
+    packages: { '@atproto/xrpc-server': '0.11.1', '@atproto/crypto': '0.5.0' },
+    script: 'generate_fixtures.mjs (this directory)',
+  },
+  iss: ISS,
+  aud: AUD,
+  lxm: LXM,
+  cases: [],
+}
+
+for (const [alg, { privHex, make }] of Object.entries(keys)) {
+  const keypair = await make(privHex)
+  const did = keypair.did()
+  const common = { iss: ISS, aud: AUD, keypair }
+
+  const withLxm = await createServiceJwt({ ...common, lxm: LXM, iat: IAT, exp: EXP })
+  const noLxm = await createServiceJwt({ ...common, lxm: null, iat: IAT, exp: EXP })
+  const expired = await createServiceJwt({ ...common, lxm: LXM, iat: IAT, exp: PAST_EXP })
+
+  // sanity: the reference accepts its own tokens
+  await verifyJwt(withLxm, AUD, LXM, async () => did)
+  await verifyJwt(noLxm, null, null, async () => did)
+
+  fixtures.cases.push({
+    alg,
+    private_key_hex: privHex,
+    did_key: did,
+    tokens: {
+      with_lxm: { token: withLxm, claims: { iat: IAT, iss: ISS, aud: AUD, exp: EXP, lxm: LXM } },
+      no_lxm: { token: noLxm, claims: { iat: IAT, iss: ISS, aud: AUD, exp: EXP } },
+      expired: { token: expired, claims: { iat: IAT, iss: ISS, aud: AUD, exp: PAST_EXP, lxm: LXM } },
+    },
+  })
+}
+
+console.log(JSON.stringify(fixtures, null, 2))

--- a/test/atproto/service_auth/jwt_fixtures.json
+++ b/test/atproto/service_auth/jwt_fixtures.json
@@ -1,0 +1,89 @@
+{
+  "_meta": {
+    "description": "Service JWTs minted by the TypeScript reference implementation for cross-implementation verification.",
+    "repository": "https://github.com/bluesky-social/atproto",
+    "commit": "3e977fe0ab88145f4ff26b491f371d3bade22505",
+    "packages": {
+      "@atproto/xrpc-server": "0.11.1",
+      "@atproto/crypto": "0.5.0"
+    },
+    "script": "generate_fixtures.mjs (this directory)"
+  },
+  "iss": "did:example:alice",
+  "aud": "did:example:bob",
+  "lxm": "com.atproto.repo.createRecord",
+  "cases": [
+    {
+      "alg": "ES256K",
+      "private_key_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+      "did_key": "did:key:zQ3shVc2UkAfJCdc1TR8E66J85h48P43r93q8jGPkPpjF9Ef9",
+      "tokens": {
+        "with_lxm": {
+          "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE3NTAwMDAwMDAsImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYXVkIjoiZGlkOmV4YW1wbGU6Ym9iIiwiZXhwIjozMjUwMzY4MDAwMCwibHhtIjoiY29tLmF0cHJvdG8ucmVwby5jcmVhdGVSZWNvcmQiLCJqdGkiOiI1ZmU5ZjUyNzc0YWQ3ZGFkMzQxOTFkZTJiNDM0NTc1ZCJ9.mfnJAiHsZhoGx00zrhnfWauPXPNTIt7xBqFQwFDY8nxwC--3Hon4TLFkvgdfafYSxRt1uREZhV9tjhymVG0ofA",
+          "claims": {
+            "iat": 1750000000,
+            "iss": "did:example:alice",
+            "aud": "did:example:bob",
+            "exp": 32503680000,
+            "lxm": "com.atproto.repo.createRecord"
+          }
+        },
+        "no_lxm": {
+          "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE3NTAwMDAwMDAsImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYXVkIjoiZGlkOmV4YW1wbGU6Ym9iIiwiZXhwIjozMjUwMzY4MDAwMCwianRpIjoiNGE5NDcwMjdjZDU4N2NhZWUxODM1MjU3Yjc5YjNjMjgifQ._kAEmtIZyB2qkxaNwEz3_fRlZZyHqKQTwFfwo8A42mlULkvzR7no7HtzD9j6WwrWOwU5-vrDAeteK8BnoOdDBg",
+          "claims": {
+            "iat": 1750000000,
+            "iss": "did:example:alice",
+            "aud": "did:example:bob",
+            "exp": 32503680000
+          }
+        },
+        "expired": {
+          "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE3NTAwMDAwMDAsImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYXVkIjoiZGlkOmV4YW1wbGU6Ym9iIiwiZXhwIjoxNzUwMDAwMDYwLCJseG0iOiJjb20uYXRwcm90by5yZXBvLmNyZWF0ZVJlY29yZCIsImp0aSI6IjkyMzc3YzM0MTEzN2YxN2NjYmNmNTA3Y2QyMDliMzU0In0.L1q4hoEgvNR6R65BN92cVcLbbE13tErZYlMSnU9p518oyBIYXbiIqAOxvws0yCm0mUwpqPQN3U5hfOB0LPhvDg",
+          "claims": {
+            "iat": 1750000000,
+            "iss": "did:example:alice",
+            "aud": "did:example:bob",
+            "exp": 1750000060,
+            "lxm": "com.atproto.repo.createRecord"
+          }
+        }
+      }
+    },
+    {
+      "alg": "ES256",
+      "private_key_hex": "0000000000000000000000000000000000000000000000000000000000000002",
+      "did_key": "did:key:zDnaer52RTwabaBeMkKYYwZmEFqPabLW78cRK62iovMUQhFif",
+      "tokens": {
+        "with_lxm": {
+          "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE3NTAwMDAwMDAsImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYXVkIjoiZGlkOmV4YW1wbGU6Ym9iIiwiZXhwIjozMjUwMzY4MDAwMCwibHhtIjoiY29tLmF0cHJvdG8ucmVwby5jcmVhdGVSZWNvcmQiLCJqdGkiOiJkNGE3NTViMjdiY2EzNjc5MDlkNzZlNzRhMzI4ODY1ZiJ9.aL5Xa2wI6hRjzuO18_N2wGNKLaVy0rDMVIclvAxiYrlcO52yXWdIVG-VxNo4cK3C0ngdSi5yxxCS532RD3CBrA",
+          "claims": {
+            "iat": 1750000000,
+            "iss": "did:example:alice",
+            "aud": "did:example:bob",
+            "exp": 32503680000,
+            "lxm": "com.atproto.repo.createRecord"
+          }
+        },
+        "no_lxm": {
+          "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE3NTAwMDAwMDAsImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYXVkIjoiZGlkOmV4YW1wbGU6Ym9iIiwiZXhwIjozMjUwMzY4MDAwMCwianRpIjoiODE1MjRkNjRmY2RlYzEwY2VhY2Q2MDk3MGZiYmFhZGQifQ.SGMFP63XTVEsouYkFyAQjatD9-7_iDE6hmZeMBliIsYCgA6VBR6Fyttg1MzIwInXWets8l-W0t1S4nY6yw37hg",
+          "claims": {
+            "iat": 1750000000,
+            "iss": "did:example:alice",
+            "aud": "did:example:bob",
+            "exp": 32503680000
+          }
+        },
+        "expired": {
+          "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE3NTAwMDAwMDAsImlzcyI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYXVkIjoiZGlkOmV4YW1wbGU6Ym9iIiwiZXhwIjoxNzUwMDAwMDYwLCJseG0iOiJjb20uYXRwcm90by5yZXBvLmNyZWF0ZVJlY29yZCIsImp0aSI6IjUwMGM0OTAzYzM1ODE1YWU0NmNlZTMxNTIyNGY4YjAxIn0.YeEpncHkWBe2vLubgjsysMGuZ4rzmUbz1Wgy8lIqlC4uB2pJeAzwADhry7k2pdk8vq1vnOfP6fhhM7K9uty7VQ",
+          "claims": {
+            "iat": 1750000000,
+            "iss": "did:example:alice",
+            "aud": "did:example:bob",
+            "exp": 1750000060,
+            "lxm": "com.atproto.repo.createRecord"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/atproto/service_auth_test.cljc
+++ b/test/atproto/service_auth_test.cljc
@@ -1,0 +1,397 @@
+(ns atproto.service-auth-test
+  "Tests for atproto inter-service JWT minting and verification.
+
+  Live verification (manual, run once before merge — not part of CI):
+
+    ;; 1. getServiceAuth round-trip against a real PDS:
+    (require '[atproto.credentials :as credentials]
+             '[atproto.xrpc.client :as xrpc-client]
+             '[atproto.service-auth :as service-auth])
+    (def session @(credentials/create {:identifier \"<handle>\" :password \"<app-password>\"}))
+    (def client (xrpc-client/init {:session session}))
+    (def pds-did \"did:web:...\") ;; the PDS's service DID
+    (def resp @(service-auth/get-service-auth
+                client {:aud pds-did :lxm \"com.atproto.server.getSession\"}))
+    ;; => {:token \"eyJ...\"}
+    ;; 2. verify it locally with real DID resolution:
+    @(service-auth/verify-jwt (:token resp)
+                              {:aud nil
+                               :lxm \"com.atproto.server.getSession\"
+                               :get-signing-key (service-auth/did-signing-key-resolver {})})
+    ;; => claims map with :iss = your account DID
+    ;; 3. negative check: mint with a throwaway keypair and confirm a real
+    ;;    relay/PDS rejects it with a BadJwtSignature-class 401.
+
+  Cross-implementation interop: tokens minted by the TS reference verify
+  here (see reference-fixture-verification-test below), and tokens minted
+  by atproto.service-auth/create-jwt with the fixture private keys were
+  verified by the reference verifyJwt (@atproto/xrpc-server 0.11.1) for
+  both ES256K and ES256 on 2026-06-11 (script: jwt_fixtures.json _meta)."
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            #?(:clj [clojure.java.io :as io])
+            [clojure.string :as str]
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.crypto :as runtime-crypto]
+            [atproto.runtime.json :as json]
+            [atproto.runtime.jwt :as jwt]
+            [atproto.crypto :as crypto]
+            [atproto.service-auth :as service-auth]
+            [atproto.xrpc.client :as xrpc-client]))
+
+(defn- result-of
+  [async-val]
+  #?(:clj (deref async-val 1000 ::timeout)))
+
+(def iss "did:example:alice")
+(def aud "did:example:bob")
+(def lxm "com.atproto.repo.createRecord")
+
+#?(:clj
+   (defn- keypair [alg]
+     (result-of (crypto/generate alg))))
+
+(defn- stub-signing-key
+  "A :get-signing-key fn that always yields this did:key."
+  [did-key]
+  (fn [_iss _force-refresh? cb] (cb {:key did-key})))
+
+#?(:clj
+   (defn- verify
+     [token opts-map]
+     (result-of (service-auth/verify-jwt token opts-map))))
+
+;; -----------------------------------------------------------------------------
+;; Mint & verify round-trip
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest mint-verify-round-trip-test
+     (doseq [alg ["ES256" "ES256K"]]
+       (let [kp (keypair alg)
+             get-key (stub-signing-key (crypto/did kp))]
+         (testing (str alg " round-trip with lxm")
+           (let [{:keys [token]} (result-of (service-auth/create-jwt
+                                             {:iss iss :aud aud :keypair kp :lxm lxm}))
+                 claims (verify token {:aud aud :lxm lxm :get-signing-key get-key})]
+             (is (string? token))
+             (is (= iss (:iss claims)))
+             (is (= aud (:aud claims)))
+             (is (= lxm (:lxm claims)))
+             (is (re-matches #"[0-9a-f]{32}" (:jti claims)))))
+         (testing (str alg " exp defaults to (now, now+60]")
+           (let [{:keys [token]} (result-of (service-auth/create-jwt
+                                             {:iss iss :aud aud :keypair kp :lxm nil}))
+                 claims (verify token {:aud nil :lxm nil :get-signing-key get-key})
+                 now (runtime-crypto/now)]
+             (is (nil? (:lxm claims)))
+             (is (< now (:exp claims)))
+             (is (<= (:exp claims) (+ now 60)))))
+         (testing (str alg " auth-headers wraps the token as a Bearer header")
+           (let [{:keys [headers]} (result-of (service-auth/auth-headers
+                                               {:iss iss :aud aud :keypair kp :lxm lxm}))]
+             (is (str/starts-with? (:authorization headers) "Bearer "))))))))
+
+#?(:clj
+   (deftest create-jwt-param-validation-test
+     (let [kp (keypair "ES256")]
+       (is (= "InvalidServiceJwtParams"
+              (:error (result-of (service-auth/create-jwt
+                                  {:iss "not-a-did" :aud aud :keypair kp})))))
+       (is (= "InvalidServiceJwtParams"
+              (:error (result-of (service-auth/create-jwt {:iss iss :aud aud}))))))))
+
+;; -----------------------------------------------------------------------------
+;; Verification failure modes
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (defn- mint
+     "Mint a token with full control over headers and claims via jwt/sign."
+     [kp headers claims]
+     (result-of (jwt/sign kp headers claims))))
+
+#?(:clj
+   (deftest verify-failure-modes-test
+     (let [kp (keypair "ES256K")
+           get-key (stub-signing-key (crypto/did kp))
+           now (runtime-crypto/now)
+           base-claims {:iat now :iss iss :aud aud :exp (+ now 60) :lxm lxm}
+           verify-error (fn [token opts-map]
+                          (let [resp (verify token (merge {:get-signing-key get-key}
+                                                          opts-map))]
+                            (is (= 401 (:status resp)) (pr-str resp))
+                            resp))]
+
+       (testing "malformed JWT strings"
+         (doseq [bad ["" "garbage" "a.b" "a.b.c.d" "!!.@@.##"]]
+           (is (= "BadJwt" (:error (verify-error bad {}))))))
+
+       (testing "forbidden typ headers"
+         (doseq [typ ["at+jwt" "refresh+jwt" "dpop+jwt"]]
+           (let [token (mint kp {:typ typ} base-claims)]
+             (is (= "BadJwtType" (:error (verify-error token {})))))))
+
+       (testing "poorly shaped payloads"
+         (doseq [claims [(dissoc base-claims :aud)
+                         (dissoc base-claims :exp)
+                         (assoc base-claims :exp "soon")
+                         (assoc base-claims :lxm 42)
+                         (dissoc base-claims :iss)]]
+           (let [token (mint kp {:typ "JWT"} claims)]
+             (is (= "BadJwt" (:error (verify-error token {})))))))
+
+       (testing "expired token"
+         (let [token (mint kp {:typ "JWT"} (assoc base-claims :exp (- now 10)))]
+           (is (= "JwtExpired" (:error (verify-error token {}))))))
+
+       (testing "wrong audience"
+         (let [token (mint kp {:typ "JWT"} base-claims)]
+           (is (= "BadJwtAudience"
+                  (:error (verify-error token {:aud "did:example:carol"}))))))
+
+       (testing "wrong vs missing lxm have distinct messages"
+         (let [wrong (verify-error (mint kp {:typ "JWT"} base-claims)
+                                   {:lxm "com.atproto.repo.deleteRecord"})
+               missing (verify-error (mint kp {:typ "JWT"} (dissoc base-claims :lxm))
+                                     {:lxm lxm})]
+           (is (= "BadJwtLexiconMethod" (:error wrong)))
+           (is (= "BadJwtLexiconMethod" (:error missing)))
+           (is (str/starts-with? (:message wrong) "bad jwt lexicon method"))
+           (is (str/starts-with? (:message missing) "missing jwt lexicon method"))))
+
+       (testing "non-DID iss"
+         (doseq [bad-iss ["alice" "did:" "did:example:alice#a#b" "did:example:alice#"]]
+           (let [token (mint kp {:typ "JWT"} (assoc base-claims :iss bad-iss))]
+             (is (= "BadJwtIss" (:error (verify-error token {})))))))
+
+       (testing "iss with a service fragment is accepted"
+         (let [token (mint kp {:typ "JWT"}
+                           (assoc base-claims :iss (str iss "#atproto_labeler")))]
+           (is (= (str iss "#atproto_labeler")
+                  (:iss (verify token {:get-signing-key get-key}))))))
+
+       (testing "bad signature"
+         (let [other (keypair "ES256K")
+               token (mint other {:typ "JWT"} base-claims)]
+           (is (= "BadJwtSignature" (:error (verify-error token {})))))))))
+
+#?(:clj
+   (deftest key-rotation-retry-test
+     (let [kp (keypair "ES256")
+           stale-kp (keypair "ES256")
+           token (:token (result-of (service-auth/create-jwt
+                                     {:iss iss :aud aud :keypair kp :lxm lxm})))
+           calls (atom [])]
+
+       (testing "stale key first, fresh key on force-refresh -> success"
+         (reset! calls [])
+         (let [get-key (fn [_iss force-refresh? cb]
+                         (swap! calls conj force-refresh?)
+                         (cb {:key (crypto/did (if force-refresh? kp stale-kp))}))
+               claims (verify token {:get-signing-key get-key})]
+           (is (= iss (:iss claims)))
+           (is (= [false true] @calls))))
+
+       (testing "same key twice -> BadJwtSignature without a second signature check"
+         (reset! calls [])
+         (let [sig-checks (atom 0)
+               get-key (fn [_iss force-refresh? cb]
+                         (swap! calls conj force-refresh?)
+                         (cb {:key (crypto/did stale-kp)}))
+               counting-verify (fn [did-key sig msg & {:keys [callback] :as opts}]
+                                 (swap! sig-checks inc)
+                                 (crypto/verify-did-sig did-key sig msg
+                                                        (assoc opts :callback callback)))
+               resp (verify token {:get-signing-key get-key
+                                   :verify-signature counting-verify})]
+           (is (= "BadJwtSignature" (:error resp)))
+           (is (= 401 (:status resp)))
+           (is (= [false true] @calls))
+           (is (= 1 @sig-checks))))
+
+       (testing "get-signing-key errors pass through"
+         (let [get-key (fn [_iss _force-refresh? cb]
+                         (cb {:error "UntrustedIss" :message "Untrusted issuer"}))
+               resp (verify token {:get-signing-key get-key})]
+           (is (= "UntrustedIss" (:error resp)))
+           (is (= 401 (:status resp))))))))
+
+;; -----------------------------------------------------------------------------
+;; Cross-implementation fixtures (tokens minted by the TS reference)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (def jwt-fixtures
+     (json/read-str (slurp (io/resource "atproto/service_auth/jwt_fixtures.json")))))
+
+#?(:clj
+   (deftest reference-fixture-verification-test
+     (doseq [{:keys [alg did_key private_key_hex tokens]} (:cases jwt-fixtures)]
+       (let [get-key (stub-signing-key did_key)]
+         (testing (str alg " reference token with lxm verifies")
+           (let [{:keys [token claims]} (:with_lxm tokens)
+                 verified (verify token {:aud (:aud jwt-fixtures)
+                                         :lxm (:lxm jwt-fixtures)
+                                         :get-signing-key get-key})]
+             (is (= (dissoc claims :jti) (dissoc verified :jti)))
+             (is (re-matches #"[0-9a-f]{32}" (:jti verified)))))
+         (testing (str alg " reference token without lxm verifies (lxm check skipped)")
+           (let [{:keys [token]} (:no_lxm tokens)]
+             (is (= (:iss jwt-fixtures)
+                    (:iss (verify token {:aud nil :lxm nil :get-signing-key get-key}))))))
+         (testing (str alg " reference token without lxm fails a bound route")
+           (let [{:keys [token]} (:no_lxm tokens)]
+             (is (= "BadJwtLexiconMethod"
+                    (:error (verify token {:lxm (:lxm jwt-fixtures)
+                                           :get-signing-key get-key}))))))
+         (testing (str alg " expired reference token")
+           (let [{:keys [token]} (:expired tokens)]
+             (is (= "JwtExpired"
+                    (:error (verify token {:get-signing-key get-key}))))))
+         (testing (str alg " fixture private key imports to the fixture did:key")
+           (let [kp (result-of (crypto/import-private-key alg private_key_hex))]
+             (is (= did_key (crypto/did kp)))))))))
+
+;; -----------------------------------------------------------------------------
+;; did-signing-key-resolver
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (defn- stub-resolve-did
+     "An identity/resolve-did stand-in serving canned DID documents."
+     [docs-by-did & [calls]]
+     (fn [did & {:keys [force-refresh callback]}]
+       (when calls (swap! calls conj [did (boolean force-refresh)]))
+       (callback (if-let [doc (get docs-by-did did)]
+                   {:did-doc doc}
+                   {:error "DidNotFound"})))))
+
+#?(:clj
+   (deftest did-signing-key-resolver-test
+     (let [kp (keypair "ES256K")
+           label-kp (keypair "ES256")
+           multikey (crypto/format-multikey "ES256K" (crypto/public-key kp))
+           label-multikey (crypto/format-multikey "ES256" (crypto/public-key label-kp))
+           did-doc {:id iss
+                    :verificationMethod
+                    [{:id (str iss "#atproto")
+                      :type "Multikey"
+                      :controller iss
+                      :publicKeyMultibase multikey}
+                     {:id (str iss "#atproto_label")
+                      :type "Multikey"
+                      :controller iss
+                      :publicKeyMultibase label-multikey}]}
+           resolve-did (stub-resolve-did {iss did-doc})
+           resolver (service-auth/did-signing-key-resolver {:resolve-did resolve-did})
+           get-key (fn [resolver iss force-refresh?]
+                     (let [p (promise)]
+                       (resolver iss force-refresh? #(deliver p %))
+                       (deref p 1000 ::timeout)))]
+
+       (testing "plain DID iss selects #atproto"
+         (is (= {:key (crypto/did kp)} (get-key resolver iss false))))
+
+       (testing "#atproto_labeler service fragment selects #atproto_label"
+         (is (= {:key (crypto/did label-kp)}
+                (get-key resolver (str iss "#atproto_labeler") false))))
+
+       (testing "other service fragments still select #atproto"
+         (is (= {:key (crypto/did kp)}
+                (get-key resolver (str iss "#atproto_pds") false))))
+
+       (testing "force-refresh is forwarded to resolve-did"
+         (let [calls (atom [])
+               resolver (service-auth/did-signing-key-resolver
+                         {:resolve-did (stub-resolve-did {iss did-doc} calls)})]
+           (get-key resolver iss true)
+           (is (= [[iss true]] @calls))))
+
+       (testing "legacy 2019 verification-method types convert"
+         (let [eckey-doc {:id iss
+                          :verificationMethod
+                          [{:id (str iss "#atproto")
+                            :type "EcdsaSecp256k1VerificationKey2019"
+                            :controller iss
+                            :publicKeyMultibase (crypto/bytes->multibase
+                                                 :base58btc (crypto/public-key kp))}]}
+               resolver (service-auth/did-signing-key-resolver
+                         {:resolve-did (stub-resolve-did {iss eckey-doc})})]
+           (is (= {:key (crypto/did kp)} (get-key resolver iss false)))))
+
+       (testing "allowed-issuers"
+         (let [resolver (service-auth/did-signing-key-resolver
+                         {:resolve-did resolve-did
+                          :allowed-issuers #{iss}})]
+           (is (= {:key (crypto/did kp)} (get-key resolver iss false)))
+           (let [resp (get-key resolver "did:example:mallory" false)]
+             (is (= "UntrustedIss" (:error resp)))
+             (is (= 401 (:status resp))))))
+
+       (testing "unresolvable DID"
+         (let [resp (get-key resolver "did:example:nobody" false)]
+           (is (= "AuthenticationRequired" (:error resp)))
+           (is (= "could not resolve iss did" (:message resp)))))
+
+       (testing "missing verification method"
+         (let [resolver (service-auth/did-signing-key-resolver
+                         {:resolve-did (stub-resolve-did
+                                        {iss {:id iss :verificationMethod []}})})
+               resp (get-key resolver iss false)]
+           (is (= "AuthenticationRequired" (:error resp)))
+           (is (= "missing or bad key in did doc" (:message resp))))))))
+
+;; -----------------------------------------------------------------------------
+;; Session (client-side service auth)
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (deftest session-test
+     (let [kp (keypair "ES256K")
+           sess (service-auth/session {:iss iss
+                                       :aud aud
+                                       :keypair kp
+                                       :service "https://service.example.com"})]
+
+       (testing "session exposes the target service as :pds"
+         (is (= "https://service.example.com" (:pds sess))))
+
+       (testing "refresh-token invokes its callback exactly once, with the session"
+         (let [calls (atom [])]
+           (xrpc-client/refresh-token sess #(swap! calls conj %))
+           (is (= [sess] @calls))))
+
+       (testing "auth interceptor attaches a Bearer JWT with lxm bound to the request NSID"
+         (let [interceptor (xrpc-client/auth-interceptor sess)
+               final {::i/name ::final
+                      ::i/enter (fn [ctx] (assoc ctx ::i/response (::i/request ctx)))}
+               request @(i/execute
+                         {::i/request {:method :post
+                                       :url "https://service.example.com/xrpc/com.example.method"}
+                          ::i/queue [interceptor final]})
+               authz (get-in request [:headers :authorization])
+               token (subs authz (count "Bearer "))
+               claims (verify token {:aud aud
+                                     :lxm "com.example.method"
+                                     :get-signing-key (stub-signing-key (crypto/did kp))})]
+           (is (str/starts-with? authz "Bearer "))
+           (is (= iss (:iss claims)))
+           (is (= "com.example.method" (:lxm claims)))))
+
+       (testing "a 401 through delegate-auth-interceptor delivers (no hang)"
+         (let [client (xrpc-client/init {:session sess})
+               http-401 {::i/name ::http-401
+                         ::i/enter (fn [ctx]
+                                     (assoc ctx ::i/response
+                                            {:status 401
+                                             :headers {}
+                                             :body "unauthorized"}))}
+               response (deref (i/execute
+                                {::i/request {:method :get
+                                              :url "https://service.example.com/xrpc/com.example.method"}
+                                 ::i/queue [(xrpc-client/delegate-auth-interceptor client)
+                                            http-401]})
+                               2000 ::timeout)]
+           (is (not= ::timeout response))
+           (is (= 401 (:status response))))))))

--- a/test/atproto/xrpc/frame_fixtures.json
+++ b/test/atproto/xrpc/frame_fixtures.json
@@ -1,0 +1,26 @@
+{
+  "_meta": {
+    "description": "Event-stream frame byte fixtures vendored from the TypeScript reference implementation.",
+    "source": "packages/xrpc-server/tests/frames.test.ts",
+    "repository": "https://github.com/bluesky-social/atproto",
+    "commit": "3e977fe0ab88145f4ff26b491f371d3bade22505",
+    "notes": "Byte vectors are copied verbatim from the test expectations (unsigned byte values). The message frame is MessageFrame({a:'b',c:[1,2,3]}, {type:'#d'}); the error frame is ErrorFrame({error:'BigOops',message:'Something went awry'})."
+  },
+  "message_frame": {
+    "header": {"op": 1, "t": "#d"},
+    "body": {"a": "b", "c": [1, 2, 3]},
+    "bytes": [162, 97, 116, 98, 35, 100, 98, 111, 112, 1,
+              162, 97, 97, 97, 98, 97, 99, 131, 1, 2, 3],
+    "header_length": 10
+  },
+  "error_frame": {
+    "header": {"op": -1},
+    "body": {"error": "BigOops", "message": "Something went awry"},
+    "bytes": [161, 98, 111, 112, 32,
+              162, 101, 101, 114, 114, 111, 114, 103, 66, 105, 103, 79, 111,
+              112, 115, 103, 109, 101, 115, 115, 97, 103, 101, 115, 83, 111,
+              109, 101, 116, 104, 105, 110, 103, 32, 119, 101, 110, 116, 32,
+              97, 119, 114, 121],
+    "header_length": 5
+  }
+}

--- a/test/atproto/xrpc/frames_test.cljc
+++ b/test/atproto/xrpc/frames_test.cljc
@@ -1,0 +1,90 @@
+(ns atproto.xrpc.frames-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [atproto.runtime.json :as json]
+            [atproto.runtime.bytes :as bytes]
+            [atproto.data.cbor :as cbor]
+            [atproto.xrpc.frames :as frames]
+            #?(:clj [clojure.java.io :as io])))
+
+(def fixtures
+  #?(:clj (json/read-str (slurp (io/resource "atproto/xrpc/frame_fixtures.json")))))
+
+(defn- fixture-bytes
+  ^bytes [fixture]
+  (byte-array (map unchecked-byte (:bytes fixture))))
+
+(defn- concat-bytes
+  ^bytes [& bs]
+  (byte-array (mapcat seq bs)))
+
+(deftest message-frame-fixture-test
+  (let [{:keys [header body] :as fixture} (:message_frame fixtures)
+        expected (fixture-bytes fixture)]
+    (testing "encode matches the reference bytes exactly"
+      (is (bytes/eq? expected
+                     (frames/encode {:op 1 :t (:t header) :body body}))))
+    (testing "message-frame lifts :$type into the header"
+      (is (bytes/eq? expected
+                     (frames/encode (frames/message-frame
+                                     (assoc body :$type "com.example.stream#d")
+                                     :nsid "com.example.stream")))))
+    (testing "decode inverts encode"
+      (is (= {:op 1 :t "#d" :body body}
+             (frames/decode expected))))))
+
+(deftest error-frame-fixture-test
+  (let [{:keys [body] :as fixture} (:error_frame fixtures)
+        expected (fixture-bytes fixture)]
+    (testing "encode matches the reference bytes exactly"
+      (is (bytes/eq? expected
+                     (frames/encode (frames/error-frame (:error body) (:message body))))))
+    (testing "decode inverts encode"
+      (is (= {:op -1 :body body}
+             (frames/decode expected))))))
+
+(deftest type-lifting-test
+  (testing "compresses #frag when the nsid matches"
+    (is (= {:op 1 :t "#commit" :body {:a 1}}
+           (frames/message-frame {:$type "com.example.stream#commit" :a 1}
+                                 :nsid "com.example.stream"))))
+  (testing "compresses a bare #frag $type"
+    (is (= {:op 1 :t "#commit" :body {:a 1}}
+           (frames/message-frame {:$type "#commit" :a 1}
+                                 :nsid "com.example.stream"))))
+  (testing "keeps the full $type when the nsid differs"
+    (is (= {:op 1 :t "com.other.stream#commit" :body {:a 1}}
+           (frames/message-frame {:$type "com.other.stream#commit" :a 1}
+                                 :nsid "com.example.stream"))))
+  (testing "no :t without a string $type"
+    (is (= {:op 1 :body {:a 1}}
+           (frames/message-frame {:a 1} :nsid "com.example.stream")))
+    (is (= {:op 1 :body [1 2 3]}
+           (frames/message-frame [1 2 3] :nsid "com.example.stream")))))
+
+(deftest decode-rejection-test
+  (let [message (fixture-bytes (:message_frame fixtures))
+        header-only #?(:clj (byte-array (take (:header_length (:message_frame fixtures))
+                                              (seq message))))]
+    (testing "not CBOR at all"
+      (is (= "InvalidFrame" (:error (frames/decode #?(:clj (.getBytes "some utf8 bytes" "UTF-8"))))))
+      (is (= "InvalidFrame" (:error (frames/decode (byte-array 0))))))
+    (testing "unknown header op"
+      (is (= "InvalidFrame"
+             (:error (frames/decode (concat-bytes (cbor/encode {:op -2})
+                                                  (cbor/encode {:a "b"})))))))
+    (testing "missing body"
+      (is (= "InvalidFrame" (:error (frames/decode header-only)))))
+    (testing "too many CBOR data items"
+      (is (= "InvalidFrame"
+             (:error (frames/decode (concat-bytes message
+                                                  (cbor/encode {:d "e"})))))))
+    (testing "invalid error frame body"
+      (is (= "InvalidFrame"
+             (:error (frames/decode (concat-bytes (cbor/encode {:op -1})
+                                                  (cbor/encode {:blah 1})))))))))
+
+(deftest encode-rejection-test
+  (testing "invalid op throws"
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (frames/encode {:op 2 :body {}})))))

--- a/test/atproto/xrpc/rate_limit_test.cljc
+++ b/test/atproto/xrpc/rate_limit_test.cljc
@@ -1,0 +1,66 @@
+(ns atproto.xrpc.rate-limit-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [atproto.xrpc.rate-limit :as rate-limit]))
+
+(defn- consume!
+  [limiter ctx]
+  (let [result (atom ::none)]
+    (rate-limit/consume limiter ctx #(reset! result %))
+    @result))
+
+(deftest memory-limiter-test
+  (let [limiter (rate-limit/memory {:key-prefix "t"
+                                    :duration-ms 60000
+                                    :points 2
+                                    :calc-key (constantly "k")})]
+    (testing "status map shape while under the limit"
+      (let [status (consume! limiter {})]
+        (is (= {:limit 2 :duration 60 :remaining-points 1 :consumed-points 1}
+               (select-keys status [:limit :duration :remaining-points :consumed-points])))
+        (is (pos? (:ms-before-next status)))))
+    (testing "exceeding the limit"
+      (consume! limiter {})
+      (let [result (consume! limiter {})]
+        (is (= "RateLimitExceeded" (:error result)))
+        (is (= 429 (:status result)))
+        (is (= 0 (:remaining-points (:ratelimit-status result))))))
+    (testing "reset clears the counter"
+      (rate-limit/reset limiter {} identity)
+      (is (= 1 (:consumed-points (consume! limiter {})))))
+    (testing "calc-points below 1 skips"
+      (is (nil? (consume! limiter {::rate-limit/calc-points (constantly 0)}))))))
+
+(deftest wrapped-limiter-test
+  (let [limiter (rate-limit/memory {:key-prefix "w"
+                                    :duration-ms 60000
+                                    :points 10
+                                    :calc-key (constantly "default")})
+        per-user (rate-limit/wrapped limiter
+                                     {:calc-key (fn [ctx] (get-in ctx [:auth :did]))
+                                      :calc-points (constantly 5)})]
+    (testing "overridden key and points"
+      (is (= 5 (:consumed-points (consume! per-user {:auth {:did "did:example:a"}}))))
+      (is (= 9 (:remaining-points (consume! limiter {})))
+          "the wrapped limiter consumed under a separate key")
+      (is (= 0 (:remaining-points (consume! per-user {:auth {:did "did:example:a"}}))))
+      (is (= "RateLimitExceeded"
+             (:error (consume! per-user {:auth {:did "did:example:a"}})))))
+    (testing "nil key from the override skips"
+      (is (nil? (consume! per-user {}))))))
+
+(deftest combined-limiter-test
+  (let [loose (rate-limit/memory {:key-prefix "loose"
+                                  :duration-ms 60000
+                                  :points 100
+                                  :calc-key (constantly "k")})
+        tight (rate-limit/memory {:key-prefix "tight"
+                                  :duration-ms 60000
+                                  :points 2
+                                  :calc-key (constantly "k")})
+        both (rate-limit/combined [loose tight])]
+    (testing "tightest status wins"
+      (is (= 1 (:remaining-points (consume! both {}))))
+      (is (= 0 (:remaining-points (consume! both {})))))
+    (testing "any exceeded result short-circuits"
+      (is (= "RateLimitExceeded" (:error (consume! both {})))))))

--- a/test/atproto/xrpc/server_test.cljc
+++ b/test/atproto/xrpc/server_test.cljc
@@ -6,6 +6,9 @@
             [atproto.runtime.http :as http]
             [atproto.runtime.json :as json]
             [atproto.lexicon :as lexicon]
+            [atproto.crypto :as crypto]
+            [atproto.service-auth :as service-auth]
+            [atproto.xrpc.rate-limit :as rate-limit]
             [atproto.xrpc.server :as server]))
 
 ;; TODO:
@@ -119,10 +122,15 @@
     (are [http-request] (invalid-request? (execute http-request))
       {:method :get  :url (url "com.example")}
       {:method :post :url (url "com.example.query")}
-      {:method :get  :url (url "com.example.unknown")}
       {:method :get  :url (url "com.example.query")}
       {:method :get  :url (url "com.example.query") :query-params {:filter "foo"}}
       {:method :post :url (url "com.example.procedure") :input {:encoding "text/plain" :body "test"}}))
+
+  (testing "valid-but-unknown NSID is 501, malformed XRPC path is 400 (reference catchall)"
+    (is (method-not-implemented? (execute {:method :get :url (url "com.example.unknown")})))
+    (is (invalid-request? (execute {:method :get :url "http://example.com/xrpc/"})))
+    (is (invalid-request? (execute {:method :get :url "http://example.com/other/com.example.query"})))
+    (is (invalid-request? (execute {:method :get :url (url "not a nsid")}))))
 
   (testing "response validation"
     (binding [*impl* (constantly {:encoding "application/json"
@@ -131,6 +139,256 @@
        (invalid-response? (execute {:method :get
                                     :url (url "com.example.query")
                                     :query-params {:filter true}}))))))
+
+;; -----------------------------------------------------------------------------
+;; Auth
+;; -----------------------------------------------------------------------------
+
+(defn- token-auth-verifier
+  "Auth verifier accepting exactly `Bearer <expected>`."
+  [expected]
+  (fn [{:keys [request]} cb]
+    (if (= (get-in request [:headers :authorization]) (str "Bearer " expected))
+      (cb {:credentials {:did "did:example:alice"}})
+      (cb {:error "AuthenticationRequired" :message "bad token" :status 401}))))
+
+(defn- execute-with
+  [config http-request]
+  @(i/execute {::i/request http-request
+               ::i/queue [(server/interceptor (merge server config))]}))
+
+(deftest auth-pipeline-test
+  (let [config {:auth {"com.example.query" (token-auth-verifier "sesame")
+                       "com.example.procedure" (token-auth-verifier "sesame")}}]
+
+    (testing "auth success exposes :auth to handle"
+      (binding [*impl* (fn [{:keys [auth]}]
+                         (is (= {:credentials {:did "did:example:alice"}} auth))
+                         {:encoding "application/json"
+                          :body {:status "ok"}})]
+        (let [resp (execute-with config
+                                 {:method :get
+                                  :url (url "com.example.query")
+                                  :query-params {:filter true}
+                                  :headers {:authorization "Bearer sesame"}})]
+          (is (= 200 (:status resp))))))
+
+    (testing "auth failure returns the verifier's status and error body"
+      (binding [*impl* (fn [_] (throw (ex-info "handler must not run" {})))]
+        (let [resp (execute-with config
+                                 {:method :get
+                                  :url (url "com.example.query")
+                                  :query-params {:filter true}
+                                  :headers {:authorization "Bearer wrong"}})]
+          (is (= 401 (:status resp)))
+          (is (= {:error "AuthenticationRequired" :message "bad token"}
+                 (:body resp))))))
+
+    (testing "routes without a verifier stay unauthenticated"
+      (binding [*impl* (fn [{:keys [auth]}]
+                         (is (nil? auth))
+                         {:encoding "application/json"
+                          :body {:status "ok"}})]
+        (is (= 200 (:status (execute-with {:auth {"com.example.procedure"
+                                                  (token-auth-verifier "sesame")}}
+                                          {:method :get
+                                           :url (url "com.example.query")
+                                           :query-params {:filter true}}))))))
+
+    (testing ":default verifier applies to routes without a specific entry"
+      (let [resp (execute-with {:auth {:default (token-auth-verifier "sesame")}}
+                               {:method :get
+                                :url (url "com.example.query")
+                                :query-params {:filter true}})]
+        (is (= 401 (:status resp)))))
+
+    (testing "bad auth fails before an invalid request payload"
+      (binding [*impl* (fn [_] (throw (ex-info "handler must not run" {})))]
+        (let [resp (execute-with config
+                                 {:method :post
+                                  :url (url "com.example.procedure")
+                                  :headers {:content-type "text/plain"
+                                            :authorization "Bearer wrong"}
+                                  :body (byte-array [0])})]
+          (is (= 401 (:status resp)))
+          (is (= "AuthenticationRequired" (get-in resp [:body :error]))))))
+
+    (testing "good auth still fails on the invalid payload"
+      (binding [*impl* (fn [_] (throw (ex-info "handler must not run" {})))]
+        (let [resp (execute-with config
+                                 {:method :post
+                                  :url (url "com.example.procedure")
+                                  :headers {:content-type "text/plain"
+                                            :authorization "Bearer sesame"}
+                                  :body (byte-array [0])})]
+          (is (invalid-request? resp)))))
+
+    (testing "invalid params fail before auth"
+      (let [verifier-calls (atom 0)
+            resp (execute-with {:auth {"com.example.query"
+                                       (fn [_ctx cb]
+                                         (swap! verifier-calls inc)
+                                         (cb {:credentials {}}))}}
+                               {:method :get
+                                :url (url "com.example.query")
+                                :query-params {:filter "foo"}})]
+        (is (invalid-request? resp))
+        (is (zero? @verifier-calls))))))
+
+#?(:clj
+   (deftest service-auth-verifier-test
+     (let [kp @(crypto/generate "ES256K")
+           own-did "did:example:bob"
+           verifier (server/service-auth-verifier
+                     {:own-did own-did
+                      :get-signing-key (fn [_iss _force-refresh? cb]
+                                         (cb {:key (crypto/did kp)}))})
+           config {:auth {"com.example.query" verifier}}
+           token (fn [lxm]
+                   (:token @(service-auth/create-jwt {:iss "did:example:alice"
+                                                      :aud own-did
+                                                      :keypair kp
+                                                      :lxm lxm})))]
+
+       (testing "valid service JWT: 200 and :service credentials"
+         (binding [*impl* (fn [{:keys [auth]}]
+                            (is (= :service (get-in auth [:credentials :type])))
+                            (is (= "did:example:alice" (get-in auth [:credentials :did])))
+                            {:encoding "application/json"
+                             :body {:status "ok"}})]
+           (let [resp (execute-with config
+                                    {:method :get
+                                     :url (url "com.example.query")
+                                     :query-params {:filter true}
+                                     :headers {:authorization (str "Bearer " (token "com.example.query"))}})]
+             (is (= 200 (:status resp))))))
+
+       (testing "missing Authorization: 401 MissingJwt"
+         (let [resp (execute-with config
+                                  {:method :get
+                                   :url (url "com.example.query")
+                                   :query-params {:filter true}})]
+           (is (= 401 (:status resp)))
+           (is (= "MissingJwt" (get-in resp [:body :error])))))
+
+       (testing "lxm bound to a different nsid: 401 BadJwtLexiconMethod"
+         (let [resp (execute-with config
+                                  {:method :get
+                                   :url (url "com.example.query")
+                                   :query-params {:filter true}
+                                   :headers {:authorization (str "Bearer " (token "com.example.other"))}})]
+           (is (= 401 (:status resp)))
+           (is (= "BadJwtLexiconMethod" (get-in resp [:body :error]))))))))
+
+;; -----------------------------------------------------------------------------
+;; Error mapping
+;; -----------------------------------------------------------------------------
+
+(deftest error-mapping-test
+  (testing "custom lexicon error names pass through with their status"
+    (binding [*impl* (constantly {:error "MyCustomError"
+                                  :status 400
+                                  :message "custom detail"})]
+      (let [resp (execute {:method :get
+                           :url (url "com.example.query")
+                           :query-params {:filter true}})]
+        (is (= 400 (:status resp)))
+        (is (= {:error "MyCustomError" :message "custom detail"} (:body resp))))))
+
+  (testing "an :error without :status maps to a generic 500"
+    (binding [*impl* (constantly {:error "Whoops"})]
+      (is (internal-server-error? (execute {:method :get
+                                            :url (url "com.example.query")
+                                            :query-params {:filter true}})))))
+
+  (testing "5xx messages are sanitized, error names preserved"
+    (binding [*impl* (constantly {:error "UpstreamFailure"
+                                  :status 502
+                                  :message "secret internal detail"})]
+      (let [resp (execute {:method :get
+                           :url (url "com.example.query")
+                           :query-params {:filter true}})]
+        (is (= 502 (:status resp)))
+        (is (= {:error "UpstreamFailure" :message "Upstream Failure"} (:body resp))))))
+
+  (testing "InvalidResponse spec explanations never leak"
+    (binding [*impl* (constantly {:encoding "application/json"
+                                  :body {:status "not-ok"}})]
+      (let [resp (execute {:method :get
+                           :url (url "com.example.query")
+                           :query-params {:filter true}})]
+        (is (= 500 (:status resp)))
+        (is (= {:error "InvalidResponse" :message "Internal Server Error"}
+               (:body resp))))))
+
+  (testing "a throwing handler maps to a generic 500"
+    (binding [*impl* (fn [_] (throw (ex-info "secret" {})))]
+      (is (internal-server-error? (execute {:method :get
+                                            :url (url "com.example.query")
+                                            :query-params {:filter true}})))))
+
+  (testing "error helper status table"
+    (are [status error helper] (= {:status status :error error}
+                                  (select-keys helper [:status :error]))
+      400 "InvalidRequest"         (server/invalid-request "m")
+      401 "AuthenticationRequired" (server/auth-required)
+      403 "Forbidden"              (server/forbidden)
+      404 "XRPCNotSupported"       (server/xrpc-not-supported)
+      406 "NotAcceptable"          (server/not-acceptable)
+      413 "PayloadTooLarge"        (server/payload-too-large)
+      415 "UnsupportedMediaType"   (server/unsupported-media-type)
+      429 "RateLimitExceeded"      (server/rate-limit-exceeded)
+      500 "InternalServerError"    (server/internal-server-error)
+      501 "MethodNotImplemented"   (server/method-not-implemented)
+      502 "UpstreamFailure"        (server/upstream-failure)
+      503 "NotEnoughResources"     (server/not-enough-resources)
+      504 "UpstreamTimeout"        (server/upstream-timeout))))
+
+;; -----------------------------------------------------------------------------
+;; Rate limiting
+;; -----------------------------------------------------------------------------
+
+(deftest rate-limit-test
+  (let [request {:method :get
+                 :url (url "com.example.query")
+                 :query-params {:filter true}}]
+    (binding [*impl* (constantly {:encoding "application/json"
+                                  :body {:status "ok"}})]
+
+      (testing "requests beyond the limit get a 429 with RateLimit-* headers"
+        (let [limiter (rate-limit/memory {:key-prefix "test"
+                                          :duration-ms 60000
+                                          :points 2
+                                          :calc-key (constantly "k")})
+              config {:rate-limit {:routes {"com.example.query" [limiter]}}}
+              ok1 (execute-with config request)
+              ok2 (execute-with config request)
+              limited (execute-with config request)]
+          (is (= 200 (:status ok1)))
+          (is (= "2" (get-in ok1 [:headers :ratelimit-limit])))
+          (is (= "1" (get-in ok1 [:headers :ratelimit-remaining])))
+          (is (= "0" (get-in ok2 [:headers :ratelimit-remaining])))
+          (is (= 429 (:status limited)))
+          (is (= "RateLimitExceeded" (get-in limited [:body :error])))
+          (is (= "0" (get-in limited [:headers :ratelimit-remaining])))))
+
+      (testing "global limiters apply to every route"
+        (let [limiter (rate-limit/memory {:key-prefix "global"
+                                          :duration-ms 60000
+                                          :points 1
+                                          :calc-key (constantly "k")})
+              config {:rate-limit {:global [limiter]}}]
+          (is (= 200 (:status (execute-with config request))))
+          (is (= 429 (:status (execute-with config request))))))
+
+      (testing "a nil calc-key skips the limiter"
+        (let [limiter (rate-limit/memory {:key-prefix "skip"
+                                          :duration-ms 60000
+                                          :points 1
+                                          :calc-key (constantly nil)})
+              config {:rate-limit {:global [limiter]}}]
+          (is (= 200 (:status (execute-with config request))))
+          (is (= 200 (:status (execute-with config request)))))))))
 
 (comment
 

--- a/test/atproto/xrpc/subscription_test.clj
+++ b/test/atproto/xrpc/subscription_test.clj
@@ -1,0 +1,302 @@
+(ns atproto.xrpc.subscription-test
+  "JVM integration tests for the websocket subscription transport:
+  http-kit server + ring adapter on one side, java.net.http.WebSocket as a
+  vanilla binary websocket client on the other (pattern from
+  atproto.jetstream)."
+  (:require [clojure.test :refer :all]
+            [clojure.core.async :as async]
+            [org.httpkit.server :as httpkit]
+            [atproto.lexicon :as lexicon]
+            [atproto.crypto :as crypto]
+            [atproto.service-auth :as service-auth]
+            [atproto.xrpc.client :as xrpc-client]
+            [atproto.xrpc.frames :as frames]
+            [atproto.xrpc.server :as xrpc-server]
+            [atproto.xrpc.server.ring :as ring])
+  (:import [java.io ByteArrayOutputStream]
+           [java.net URI]
+           [java.net.http HttpClient WebSocket WebSocket$Listener]
+           [java.nio ByteBuffer]
+           [java.time Duration]
+           [java.util.concurrent CompletableFuture]))
+
+(set! *warn-on-reflection* true)
+
+;; Mirrors the countdown subscription of the reference
+;; packages/xrpc-server/tests/subscriptions.test.ts LEXICONS.
+(def test-lexicon
+  (lexicon/lexicon
+   [{:lexicon 1
+     :id "io.example.stream"
+     :defs {:main {:type "subscription"
+                   :parameters {:type "params"
+                                :required ["countdown"]
+                                :properties {:countdown {:type "integer"
+                                                         :minimum 0}}}
+                   :message {:schema {:type "union"
+                                      :refs ["#message"]}}}
+            :message {:type "object"
+                      :required ["num"]
+                      :properties {:num {:type "integer"}}}}}
+    {:lexicon 1
+     :id "io.example.streamBoom"
+     :defs {:main {:type "subscription"}}}
+    {:lexicon 1
+     :id "io.example.streamAuth"
+     :defs {:main {:type "subscription"}}}
+    {:lexicon 1
+     :id "io.example.streamForever"
+     :defs {:main {:type "subscription"}}}
+    {:lexicon 1
+     :id "io.example.query"
+     :defs {:main {:type "query"
+                   :output {:encoding "application/json"
+                            :schema {:type "object"
+                                     :properties {:ok {:type "boolean"}}}}}}}
+    {:lexicon 1
+     :id "io.example.authQuery"
+     :defs {:main {:type "query"
+                   :output {:encoding "application/json"
+                            :schema {:type "object"
+                                     :properties {:did {:type "string"
+                                                        :format "did"}}}}}}}]))
+
+(defmethod xrpc-server/handle-subscription "io.example.stream"
+  [_app-ctx {:keys [params]}]
+  (let [messages (async/chan 8)]
+    (async/go
+      (loop [n (:countdown params)]
+        (if (neg? n)
+          (async/close! messages)
+          (do (async/>! messages {:$type "io.example.stream#message" :num n})
+              (recur (dec n))))))
+    {:messages messages}))
+
+(defmethod xrpc-server/handle-subscription "io.example.streamBoom"
+  [_app-ctx _request]
+  (let [messages (async/chan 8)]
+    (async/go
+      (async/>! messages {:$type "io.example.streamBoom#message" :num 1})
+      (async/>! messages {:frame/error "BoomError" :frame/message "It blew up"}))
+    {:messages messages}))
+
+(defmethod xrpc-server/handle-subscription "io.example.streamAuth"
+  [_app-ctx {:keys [auth]}]
+  (let [messages (async/chan 1)]
+    (async/go
+      (async/>! messages {:did (get-in auth [:credentials :did])})
+      (async/close! messages))
+    {:messages messages}))
+
+(def forever-closed (atom nil))
+
+(defmethod xrpc-server/handle-subscription "io.example.streamForever"
+  [_app-ctx {:keys [close-ch]}]
+  (let [messages (async/chan)
+        closed (promise)]
+    (reset! forever-closed closed)
+    (async/go-loop [n 0]
+      (let [[_ port] (async/alts! [close-ch (async/timeout 20)])]
+        (if (= port close-ch)
+          (do (async/close! messages)
+              (deliver closed true))
+          (do (async/>! messages {:num n})
+              (recur (inc n))))))
+    {:messages messages}))
+
+(defmethod xrpc-server/handle "io.example.query"
+  [_app-ctx _request]
+  {:encoding "application/json"
+   :body {:ok true}})
+
+(def service-keypair @(crypto/generate "ES256K"))
+(def server-did "did:web:server.example.com")
+
+(defmethod xrpc-server/handle "io.example.authQuery"
+  [_app-ctx {:keys [auth]}]
+  {:encoding "application/json"
+   :body {:did (get-in auth [:credentials :did])}})
+
+(def server
+  (xrpc-server/init
+   {:lexicon test-lexicon
+    :validate-response? true
+    :auth {"io.example.streamAuth"
+           (fn [{:keys [request]} cb]
+             (if (= "Bearer sesame" (get-in request [:headers :authorization]))
+               (cb {:credentials {:did "did:example:alice"}})
+               (cb {:error "AuthenticationRequired" :message "bad token" :status 401})))
+           "io.example.authQuery"
+           (xrpc-server/service-auth-verifier
+            {:own-did server-did
+             :get-signing-key (fn [_iss _force-refresh? cb]
+                                (cb {:key (crypto/did service-keypair)}))})}}))
+
+(def ^:dynamic *port* nil)
+
+(defn- with-http-server
+  [f]
+  (let [s (httpkit/run-server (ring/handler server)
+                              {:port 0 :legacy-return-value? false})]
+    (try
+      (binding [*port* (httpkit/server-port s)]
+        (f))
+      (finally
+        (httpkit/server-stop! s)))))
+
+(use-fixtures :once with-http-server)
+
+(defn- ws-url
+  [nsid query]
+  (str "ws://127.0.0.1:" *port* "/xrpc/" nsid (when query (str "?" query))))
+
+(defn- ws-collect
+  "Connect to the url and collect binary frames until the server closes.
+
+  Returns {:frames [decoded-frame ...] :close {:code n :reason s}} or
+  {:error throwable} if the upgrade fails. With :abort-after n, aborts the
+  socket client-side after n frames."
+  [url & {:keys [headers abort-after]}]
+  (let [frames (atom [])
+        result (promise)
+        buf (ByteArrayOutputStream.)
+        maybe-abort (fn [^WebSocket ws]
+                      (when (and abort-after (<= abort-after (count @frames)))
+                        (.abort ws)
+                        (deliver result {:frames @frames :close :aborted})))
+        listener (reify WebSocket$Listener
+                   (onOpen [_ ws]
+                     (.request ws 1))
+                   (onBinary [_ ws data last?]
+                     (let [^ByteBuffer data data
+                           bytes (byte-array (.remaining data))]
+                       (.get data bytes)
+                       (.write buf bytes 0 (alength bytes)))
+                     (when last?
+                       (swap! frames conj (frames/decode (.toByteArray buf)))
+                       (.reset buf))
+                     (maybe-abort ws)
+                     (.request ws 1)
+                     nil)
+                   (onClose [_ _ws code reason]
+                     (deliver result {:frames @frames
+                                      :close {:code code :reason reason}})
+                     nil)
+                   (onError [_ _ws err]
+                     (deliver result {:frames @frames :error err})
+                     nil))
+        builder (-> (HttpClient/newHttpClient)
+                    (.newWebSocketBuilder)
+                    (.connectTimeout (Duration/ofSeconds 5)))
+        builder (reduce (fn [^java.net.http.WebSocket$Builder b [k v]]
+                          (.header b (name k) v))
+                        builder
+                        headers)]
+    (try
+      (.join ^CompletableFuture
+             (.buildAsync ^java.net.http.WebSocket$Builder builder (URI/create url) listener))
+      (catch Exception e
+        (deliver result {:error e})))
+    (deref result 5000 {:error :timeout})))
+
+(deftest countdown-stream-test
+  (testing "N message frames with lifted $type headers, then close 1000"
+    (let [{:keys [frames close error]} (ws-collect (ws-url "io.example.stream" "countdown=3"))]
+      (is (nil? error))
+      (is (= [{:op 1 :t "#message" :body {:num 3}}
+              {:op 1 :t "#message" :body {:num 2}}
+              {:op 1 :t "#message" :body {:num 1}}
+              {:op 1 :t "#message" :body {:num 0}}]
+             frames))
+      (is (= 1000 (:code close))))))
+
+(deftest bad-params-test
+  (testing "invalid params: no messages, error frame InvalidRequest, close 1008"
+    (let [{:keys [frames close error]} (ws-collect (ws-url "io.example.stream" "countdown=banana"))]
+      (is (nil? error))
+      (is (= 1 (count frames)))
+      (let [frame (first frames)]
+        (is (= -1 (:op frame)))
+        (is (= "InvalidRequest" (get-in frame [:body :error]))))
+      ;; the error name travels in the frame body; http-kit cannot attach
+      ;; a close reason (see atproto.xrpc.server.ring docstring)
+      (is (= 1008 (:code close)))))
+  (testing "missing required param"
+    (let [{:keys [frames close]} (ws-collect (ws-url "io.example.stream" nil))]
+      (is (= "InvalidRequest" (get-in (first frames) [:body :error])))
+      (is (= 1008 (:code close))))))
+
+(deftest unknown-subscription-test
+  (testing "a subscription NSID without a handler maps to MethodNotImplemented"
+    (is (= {:status 501 :error "MethodNotImplemented" :message "Method Not Implemented"}
+           (xrpc-server/handle-subscription nil {:nsid "io.example.streamNobody"})))))
+
+(deftest auth-test
+  (testing "auth verifier rejection: error frame + close 1008"
+    (let [{:keys [frames close error]} (ws-collect (ws-url "io.example.streamAuth" nil))]
+      (is (nil? error))
+      (is (= -1 (:op (first frames))))
+      (is (= "AuthenticationRequired" (get-in (first frames) [:body :error])))
+      (is (= 1008 (:code close)))))
+  (testing "authenticated subscription sees :auth credentials"
+    (let [{:keys [frames close error]} (ws-collect (ws-url "io.example.streamAuth" nil)
+                                                   :headers {:authorization "Bearer sesame"})]
+      (is (nil? error))
+      (is (= [{:op 1 :body {:did "did:example:alice"}}] frames))
+      (is (= 1000 (:code close))))))
+
+(deftest mid-stream-error-test
+  (testing "{:frame/error ...} mid-stream: error frame then close 1008 with the error name"
+    (let [{:keys [frames close error]} (ws-collect (ws-url "io.example.streamBoom" nil))]
+      (is (nil? error))
+      (is (= [{:op 1 :t "#message" :body {:num 1}}
+              {:op -1 :body {:error "BoomError" :message "It blew up"}}]
+             frames))
+      (is (= 1008 (:code close))))))
+
+(deftest client-disconnect-test
+  (testing "producer sees :close-ch close on client disconnect"
+    (reset! forever-closed nil)
+    (let [{:keys [close]} (ws-collect (ws-url "io.example.streamForever" nil)
+                                      :abort-after 2)]
+      (is (= :aborted close))
+      (let [closed @forever-closed]
+        (is (some? closed))
+        (is (true? (deref closed 5000 :timeout)))))))
+
+(deftest plain-http-on-subscription-test
+  (testing "a non-websocket request to a subscription endpoint gets an XRPC error"
+    (let [resp @(org.httpkit.client/get (str "http://127.0.0.1:" *port*
+                                             "/xrpc/io.example.stream?countdown=3"))]
+      (is (= 400 (:status resp)))))
+  (testing "queries on the same server still work over plain HTTP"
+    (let [resp @(org.httpkit.client/get (str "http://127.0.0.1:" *port*
+                                             "/xrpc/io.example.query"))]
+      (is (= 200 (:status resp))))))
+
+(deftest service-auth-round-trip-test
+  (testing "a service-auth session round-trips against the SDK's own server"
+    (let [session (service-auth/session
+                   {:iss "did:example:alice"
+                    :aud server-did
+                    :keypair service-keypair
+                    :service (str "http://127.0.0.1:" *port*)})
+          client (xrpc-client/init {:session session})
+          resp (deref (xrpc-client/query client {:nsid "io.example.authQuery"})
+                      5000 ::timeout)]
+      (is (= {:did "did:example:alice"} resp))))
+  (testing "an unauthenticated client gets 401 MissingJwt"
+    (let [client (xrpc-client/init {:service (str "http://127.0.0.1:" *port*)})
+          resp (deref (xrpc-client/query client {:nsid "io.example.authQuery"})
+                      5000 ::timeout)]
+      (is (= "MissingJwt" (:error resp)))))
+  (testing "a session for the wrong audience gets 401 BadJwtAudience"
+    (let [session (service-auth/session
+                   {:iss "did:example:alice"
+                    :aud "did:web:other.example.com"
+                    :keypair service-keypair
+                    :service (str "http://127.0.0.1:" *port*)})
+          client (xrpc-client/init {:session session})
+          resp (deref (xrpc-client/query client {:nsid "io.example.authQuery"})
+                      5000 ::timeout)]
+      (is (= "BadJwtAudience" (:error resp))))))


### PR DESCRIPTION
## Summary

Implements workstream 08 (`docs/planning/08-service-auth-xrpc-server.md`) on top of `redesign`: inter-service JWTs, pluggable XRPC server authentication, spec-conformant error mapping, rate-limit hook points, and a websocket subscription transport. Built against the merged WS-02 (DAG-CBOR) and WS-03 (crypto) contracts — no stubs needed.

## Key changes

**`atproto.service-auth` (new)**
- `create-jwt` / `auth-headers`: mint service JWTs (`iss`/`aud`/`exp`/`iat`/`lxm`/`jti`) signed with an atproto keypair via `atproto.runtime.jwt/sign` (ES256 and ES256K)
- `verify-jwt`: reference policy order (typ deny-list → payload shape → exp → aud → lxm with distinct wrong/missing messages → iss shape → signature), with the one-shot forced-refresh key-rotation retry; reference error names (`BadJwt`, `BadJwtType`, `JwtExpired`, `BadJwtAudience`, `BadJwtLexiconMethod`, `BadJwtIss`, `BadJwtSignature`, `MissingJwt`, `UntrustedIss`), all `:status 401`
- `did-signing-key-resolver`: DID-doc verification-method extraction (`#atproto` / `#atproto_label` for `#atproto_labeler` issuers), Multikey + legacy `Ecdsa*2019` types, optional `:allowed-issuers`
- `get-service-auth` (`com.atproto.server.getServiceAuth`) and a `session` implementing the WS-01 `Session` contract, minting a fresh token per request with `lxm` bound to the request NSID

**`atproto.xrpc.frames` (new)** — canonical event-stream frame codec (overview §4.7): two concatenated DAG-CBOR items, `$type` → header `t` lifting/compression, byte-exact against fixtures vendored from the reference `frames.test.ts`

**`atproto.xrpc.server`** — async-capable pipeline (params validate → auth → input validate → rate-limit → handle → output validate; auth failures fire before input validation), per-route `:auth` verifiers + `:default`, `:auth` exposed to `handle`, ready-made `service-auth-verifier`, full status table (403/404/406/413/415/429/502/503/504 added), custom lexicon error names passed through, 5xx messages sanitized, malformed `/xrpc/` path → 400 vs valid-but-unknown NSID → 501, wrong verb → 400, `clojure.edn` require fixed; `handle-subscription` + `subscription-request` for transports

**`atproto.xrpc.rate-limit` (new)** — `RateLimiter` protocol (`consume`/`reset` with calc-key/calc-points semantics), `wrapped`/`combined` combinators, in-memory limiter for tests, 429 mapping + `RateLimit-*` response headers

**`atproto.xrpc.server.ring`** — http-kit websocket upgrade for lexicon subscriptions: binary frame send loop, `{:frame/error ...}` → error frame + close 1008, channel close → 1000, `:close-ch` closed on client disconnect

## Interop

- Verify direction: committed JWT fixtures minted by `@atproto/xrpc-server` 0.11.1 / `@atproto/crypto` 0.5.0 (generation script committed beside them) verify here for both curves
- Mint direction: Clojure-minted tokens were verified by the reference `verifyJwt` at implementation time
- Frame codec is byte-exact against the reference test vectors

## Known limitations

- http-kit's `AsyncChannel.serverClose` cannot attach a websocket close *reason* (only the 2-byte code); 1008/1000 codes are sent and the error name reaches clients in the error frame body. Documented in the ring adapter.
- The manual live-PDS `getServiceAuth` acceptance check is outstanding (needs real account credentials); instructions are in the `atproto.service-auth-test` comment block.

## Testing

`clojure -X:test`: 120 tests / 1560 assertions, 0 failures (baseline before this PR: 93/1339). Includes an http-kit integration suite: countdown stream with lifted `$type` headers, bad params/auth rejection → error frame + close 1008, mid-stream error frames, client-disconnect signaling, and a full service-auth session → `service-auth-verifier` round-trip over real HTTP.

https://claude.ai/code/session_01UCVxZfsR6KHbaJVoXZU1oF