### PR TITLE
Implement XRPC client ergonomics: error handling, retry, and repo API

### DIFF
--- a/docs/planning/07-xrpc-client-ergonomics.md
+++ b/docs/planning/07-xrpc-client-ergonomics.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Planning |
+| **Status** | Implemented (milestones 1–7; CLJS datetime/http bodies deferred to WS-10 as planned) |
 | **Priority** | P1 |
 | **Estimated size** | L |
 | **Branch** | ws/07-xrpc-client-ergonomics |
@@ -524,13 +524,13 @@ Already vendored under `test/interop-test-files/syntax/` (consumed via the `inte
 
 Each is an independently mergeable, green PR.
 
-1. **TID fixes & API** — `src/atproto/tid.cljc` (padding fix, parse/compare/from-time/valid?), `test/atproto/tid_test.cljc`, fixture refresh if needed. No dependencies.
-2. **AT-URI namespace** — `src/atproto/at_uri.cljc` + tests. No dependencies.
-3. **Datetime helpers (CLJ)** — `src/atproto/runtime/datetime.cljc` additions + tests; signatures pre-agreed with WS-10. No dependencies.
-4. **Error taxonomy + retry runtime** — new `atproto.xrpc.error` + `atproto.runtime.retry` namespaces with full unit tests; *not yet wired into the client* (pure additions, mergeable even before WS-01).
-5. **Client wiring: errors, headers, proxy/labelers** *(after WS-01 merges; rebase)* — modify `src/atproto/xrpc/client.cljc` (`handle-xrpc-response` → error ns, success-headers metadata, header merge, `with-service-proxy`/`with-labelers`, non-throwing `request-validator`), docstring updates in `src/atproto/client.cljc`, `test/atproto/xrpc/client_test.cljc`.
-6. **Timeout, retry, cancellation** — `:timeout`/`:max-retries`/`:signal` request opts, `abort-signal`/`abort!`, CLJS `http.cljc` timeout/abort support, tests.
-7. **Pagination + repo conveniences** — `fetch-pages`/`fetch-all`/`page-seq` in the xrpc client; new `src/atproto/client/repo.cljc` + `test/atproto/client/repo_test.cljc` (ns `atproto.client.repo`; naming agreement with WS-04 confirmed before this milestone lands — see File ownership); live-verification notes in the PR description.
+1. ✅ **TID fixes & API** — `src/atproto/tid.cljc` (padding fix, parse/compare/from-time/valid?), `test/atproto/tid_test.cljc`, fixture refresh if needed. No dependencies. *(Done; fixtures diffed against upstream, no refresh needed.)*
+2. ✅ **AT-URI namespace** — `src/atproto/at_uri.cljc` + tests. No dependencies.
+3. ✅ **Datetime helpers (CLJ)** — `src/atproto/runtime/datetime.cljc` additions + tests; signatures pre-agreed with WS-10. No dependencies. *(CLJS bodies stubbed as `{:error "NotImplemented"}` per the WS-10 contract.)*
+4. ✅ **Error taxonomy + retry runtime** — new `atproto.xrpc.error` + `atproto.runtime.retry` namespaces with full unit tests; *not yet wired into the client* (pure additions, mergeable even before WS-01). *(The abort-signal primitives live in `atproto.runtime.retry`; `atproto.xrpc.client/abort-signal`/`abort!` delegate to them.)*
+5. ✅ **Client wiring: errors, headers, proxy/labelers** *(after WS-01 merges; rebase)* — modify `src/atproto/xrpc/client.cljc` (`handle-xrpc-response` → error ns, success-headers metadata, header merge, `with-service-proxy`/`with-labelers`, non-throwing `request-validator`), docstring updates in `src/atproto/client.cljc`, `test/atproto/xrpc/client_test.cljc`. *(Done on top of WS-01's merged client; success headers readable via `atproto.xrpc.client/response-headers`.)*
+6. ✅ **Timeout, retry, cancellation** — `:timeout`/`:max-retries`/`:signal` request opts, `abort-signal`/`abort!`, CLJS `http.cljc` timeout/abort support, tests.
+7. ✅ **Pagination + repo conveniences** — `fetch-pages`/`fetch-all`/`page-seq` in the xrpc client; new `src/atproto/client/repo.cljc` + `test/atproto/client/repo_test.cljc` (ns `atproto.client.repo`; naming agreement with WS-04 confirmed before this milestone lands — see File ownership); live-verification notes in the PR description. *(Live verification against bsky.social not run from CI; see Test plan.)*
 
 ## Risks & open questions
 

--- a/src/atproto/at_uri.cljc
+++ b/src/atproto/at_uri.cljc
@@ -1,0 +1,99 @@
+(ns atproto.at-uri
+  "Construct, parse, and access at:// URIs.
+
+  Parsing is strict: the authority must be a valid handle or DID, the
+  collection a valid NSID, and the rkey a valid record key (validated with
+  the atproto.lexicon specs)."
+  (:require [clojure.spec.alpha :as s]
+            [atproto.lexicon :as lexicon]
+            [atproto.lexicon.regex :as regex]))
+
+(def ^:private max-length (* 8 1024))
+
+(defn parse
+  "Parse an at:// URI string into
+  {:authority <did-or-handle> :collection <nsid>? :rkey <str>? :fragment <str>?}.
+
+  Returns nil if the string is not a valid at:// URI (the authority,
+  collection, and rkey segments are each validated)."
+  [s]
+  (when (and (string? s)
+             (< (count s) max-length))
+    (when-let [[_ authority collection rkey fragment] (re-matches regex/at-uri s)]
+      (when (and (s/valid? ::lexicon/at-identifier authority)
+                 (or (not collection) (s/valid? ::lexicon/nsid collection))
+                 (or (not rkey) (s/valid? ::lexicon/record-key rkey)))
+        (cond-> {:authority authority}
+          collection (assoc :collection collection)
+          rkey       (assoc :rkey rkey)
+          fragment   (assoc :fragment fragment))))))
+
+(defn valid?
+  "Whether `s` is a valid at:// URI string."
+  [s]
+  (boolean (parse s)))
+
+(defn- make*
+  [authority collection rkey]
+  (cond
+    (not (s/valid? ::lexicon/at-identifier authority))
+    {:error "InvalidAtUri"
+     :message (str "Invalid authority: " (pr-str authority))}
+
+    (and rkey (not collection))
+    {:error "InvalidAtUri"
+     :message "An rkey requires a collection."}
+
+    (and collection (not (s/valid? ::lexicon/nsid collection)))
+    {:error "InvalidAtUri"
+     :message (str "Invalid collection: " (pr-str collection))}
+
+    (and rkey (not (s/valid? ::lexicon/record-key rkey)))
+    {:error "InvalidAtUri"
+     :message (str "Invalid rkey: " (pr-str rkey))}
+
+    :else
+    (str "at://" authority
+         (when collection (str "/" collection))
+         (when rkey (str "/" rkey)))))
+
+(defn make
+  "Build a canonical at:// URI string from parts.
+
+  Validates each part; returns {:error \"InvalidAtUri\" :message ...} on bad
+  input. Accepts (make authority), (make authority collection),
+  (make authority collection rkey), or (make {:authority a :collection c :rkey r})."
+  ([parts]
+   (if (map? parts)
+     (make* (:authority parts) (:collection parts) (:rkey parts))
+     (make* parts nil nil)))
+  ([authority collection]
+   (make* authority collection nil))
+  ([authority collection rkey]
+   (make* authority collection rkey)))
+
+(defn- parts
+  [s-or-parsed]
+  (if (map? s-or-parsed)
+    s-or-parsed
+    (parse s-or-parsed)))
+
+(defn authority
+  "The authority (handle or DID) of the at:// URI, or nil."
+  [s-or-parsed]
+  (:authority (parts s-or-parsed)))
+
+(defn collection
+  "The collection NSID of the at:// URI, or nil."
+  [s-or-parsed]
+  (:collection (parts s-or-parsed)))
+
+(defn rkey
+  "The record key of the at:// URI, or nil."
+  [s-or-parsed]
+  (:rkey (parts s-or-parsed)))
+
+(defn fragment
+  "The fragment of the at:// URI (leading \"/\" included, \"#\" excluded), or nil."
+  [s-or-parsed]
+  (:fragment (parts s-or-parsed)))

--- a/src/atproto/client.cljc
+++ b/src/atproto/client.cljc
@@ -23,7 +23,13 @@
   :service            Handle, DID, or app URL to connect to.
   :session            Required to make authenticated requests to the service.
   :credentials        Convenience to automatically create a credentials-based session.
-  :validate-requests? Whether to validate requests before sending them to the server."
+  :validate-requests? Whether to validate requests before sending them to the server.
+  :headers            Map of default headers for every request (lowercase keyword keys).
+  :service-proxy      \"<did>#<service-id>\" emitted as the atproto-proxy header.
+  :labelers           Coll of labeler DIDs (or {:did ... :redact? true} maps) emitted
+                      as the atproto-accept-labelers header.
+  :timeout            Default per-request timeout in ms.
+  :max-retries        Default retry count for retryable errors (default 0 = off)."
   [{:keys [service credentials session validate-requests?] :as config} & {:as opts}]
   (let [[cb val] (i/platform-async opts)]
     (cond
@@ -56,7 +62,9 @@
       ;; Otherwise initialize an XRPC client for the service/session
       :else
       (cb (xrpc/init
-           (cond-> {:validate-requests? (boolean validate-requests?)}
+           (cond-> (merge (select-keys config [:headers :service-proxy :labelers
+                                               :timeout :max-retries])
+                          {:validate-requests? (boolean validate-requests?)})
              service (assoc :service service)
              session (assoc :session session)))))
     val))
@@ -71,10 +79,15 @@
   "Call the procedure on the server with the given parameters.
 
   The `request` map accepts the following keys:
-  :nsid      NSID of the procedure, `string`, required.
-  :params    Procedure parameters, `map`, optional.
-  :body      Body of the procedure call, `::atproto/data` or `bytes`, optional
-  :encoding  MIME type of the body, `string`, required if the body are `bytes`."
+  :nsid         NSID of the procedure, `string`, required.
+  :params       Procedure parameters, `map`, optional.
+  :body         Body of the procedure call, `::atproto/data` or `bytes`, optional
+  :encoding     MIME type of the body, `string`, required if the body are `bytes`.
+  :headers      Per-request headers, `map`, optional (override the client's
+                defaults; setting :content-type alongside a body is an error).
+  :timeout      Request timeout in ms, optional (overrides the client default).
+  :max-retries  Retry count for retryable errors, optional (default 0 = off).
+  :signal       Abort signal (see atproto.xrpc.client/abort-signal), optional."
   [client request & {:as opts}]
   (xrpc/procedure client request opts))
 
@@ -82,7 +95,11 @@
   "Issue a query against the server with the given parameters.
 
   The `request` map accepts the following keys:
-  :nsid      NSID of the query, `string`, required.
-  :params    Query parameters, `map`, optional."
+  :nsid         NSID of the query, `string`, required.
+  :params       Query parameters, `map`, optional.
+  :headers      Per-request headers, `map`, optional.
+  :timeout      Request timeout in ms, optional (overrides the client default).
+  :max-retries  Retry count for retryable errors, optional (default 0 = off).
+  :signal       Abort signal (see atproto.xrpc.client/abort-signal), optional."
   [client request & {:as opts}]
   (xrpc/query client request opts))

--- a/src/atproto/client/repo.cljc
+++ b/src/atproto/client/repo.cljc
@@ -1,0 +1,289 @@
+(ns atproto.client.repo
+  "Convenience wrappers over com.atproto.repo.* XRPC methods.
+
+  All functions follow the SDK async convention (trailing keyword options
+  with :channel/:callback/:promise, returning a platform deferred) and
+  deliver error maps on failure. `client` is an atproto.client/xrpc client.
+
+  :repo defaults to the client's authenticated DID; it is an error
+  ({:error \"NotAuthenticated\"}) if neither is available. Request maps also
+  accept the :headers/:timeout/:signal/:max-retries passthrough keys.
+
+  (Named atproto.client.repo, not atproto.repo: atproto.repo is reserved for
+  the MST/commit repository layer, mirroring @atproto/repo.)"
+  (:require [atproto.client :as client]
+            [atproto.runtime.interceptor :as i]
+            [atproto.xrpc.client :as xrpc]))
+
+(def ^:private passthrough-keys
+  [:headers :timeout :signal :max-retries])
+
+(def ^:private not-authenticated
+  {:error "NotAuthenticated"
+   :message "No :repo provided and the client has no authenticated session."})
+
+(defn- invalid-request
+  [message]
+  {:error "InvalidRequest" :message message})
+
+(defn create-record
+  "com.atproto.repo.createRecord.
+
+  m: :record      required, atproto data map
+     :collection  optional, defaults to the record's :$type
+     :repo        optional, defaults to the client's authenticated DID
+     :rkey        optional; omitted, the server generates a TID (pass
+                  e.g. (atproto.tid/next-tid) for client-side determinism)
+     :validate?   tri-state: true/false/nil (server default)
+     :swap-commit CID string for optimistic concurrency
+
+  Result body: {:uri ... :cid ...} (the uri is usable with
+  atproto.at-uri/parse)."
+  [client {:keys [record repo collection rkey validate? swap-commit] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))
+        collection (or collection (:$type record))]
+    (cond
+      (not (map? record))
+      (cb (invalid-request "A :record map is required."))
+
+      (nil? repo)
+      (cb not-authenticated)
+
+      (nil? collection)
+      (cb (invalid-request "No :collection provided and the record has no :$type."))
+
+      :else
+      (client/procedure client
+                        (merge (select-keys m passthrough-keys)
+                               {:nsid "com.atproto.repo.createRecord"
+                                :body (cond-> {:repo repo
+                                               :collection collection
+                                               :record record}
+                                        rkey (assoc :rkey rkey)
+                                        (some? validate?) (assoc :validate validate?)
+                                        swap-commit (assoc :swapCommit swap-commit))})
+                        :callback cb))
+    val))
+
+(defn get-record
+  "com.atproto.repo.getRecord.
+
+  m: :collection and :rkey required; :repo (defaults to the authenticated
+  DID) and :cid optional.
+
+  Result: {:uri ... :cid ... :value {...}}."
+  [client {:keys [repo collection rkey cid] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))]
+    (cond
+      (or (nil? collection) (nil? rkey))
+      (cb (invalid-request ":collection and :rkey are required."))
+
+      (nil? repo)
+      (cb not-authenticated)
+
+      :else
+      (client/query client
+                    (merge (select-keys m passthrough-keys)
+                           {:nsid "com.atproto.repo.getRecord"
+                            :params (cond-> {:repo repo
+                                             :collection collection
+                                             :rkey rkey}
+                                      cid (assoc :cid cid))})
+                    :callback cb))
+    val))
+
+(defn put-record
+  "com.atproto.repo.putRecord.
+
+  m: :record and :rkey required; :collection (defaults to the record's
+  :$type), :repo, :validate?, :swap-commit, :swap-record optional
+  (:swap-record may be a CID string or nil-but-provided to assert that the
+  record does not exist yet; use :swap-record only when present in m)."
+  [client {:keys [record repo collection rkey validate? swap-commit swap-record] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))
+        collection (or collection (:$type record))]
+    (cond
+      (not (map? record))
+      (cb (invalid-request "A :record map is required."))
+
+      (nil? rkey)
+      (cb (invalid-request ":rkey is required."))
+
+      (nil? repo)
+      (cb not-authenticated)
+
+      (nil? collection)
+      (cb (invalid-request "No :collection provided and the record has no :$type."))
+
+      :else
+      (client/procedure client
+                        (merge (select-keys m passthrough-keys)
+                               {:nsid "com.atproto.repo.putRecord"
+                                :body (cond-> {:repo repo
+                                               :collection collection
+                                               :rkey rkey
+                                               :record record}
+                                        (some? validate?) (assoc :validate validate?)
+                                        swap-commit (assoc :swapCommit swap-commit)
+                                        (contains? m :swap-record) (assoc :swapRecord swap-record))})
+                        :callback cb))
+    val))
+
+(defn delete-record
+  "com.atproto.repo.deleteRecord.
+
+  m: :collection and :rkey required; :repo, :swap-commit, :swap-record
+  optional."
+  [client {:keys [repo collection rkey swap-commit swap-record] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))]
+    (cond
+      (or (nil? collection) (nil? rkey))
+      (cb (invalid-request ":collection and :rkey are required."))
+
+      (nil? repo)
+      (cb not-authenticated)
+
+      :else
+      (client/procedure client
+                        (merge (select-keys m passthrough-keys)
+                               {:nsid "com.atproto.repo.deleteRecord"
+                                :body (cond-> {:repo repo
+                                               :collection collection
+                                               :rkey rkey}
+                                        swap-commit (assoc :swapCommit swap-commit)
+                                        swap-record (assoc :swapRecord swap-record))})
+                        :callback cb))
+    val))
+
+(defn- list-records-request
+  [repo {:keys [collection limit cursor] :as m}]
+  (merge (select-keys m passthrough-keys)
+         {:nsid "com.atproto.repo.listRecords"
+          :params (cond-> {:repo repo
+                           :collection collection}
+                    limit (assoc :limit limit)
+                    cursor (assoc :cursor cursor)
+                    (contains? m :reverse) (assoc :reverse (:reverse m)))}))
+
+(defn list-records
+  "com.atproto.repo.listRecords - a single page.
+
+  m: :collection required; :repo, :limit, :cursor, :reverse optional.
+
+  Result: {:records [{:uri ... :cid ... :value {...}} ...] :cursor ...}."
+  [client {:keys [repo collection] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))]
+    (cond
+      (nil? collection) (cb (invalid-request ":collection is required."))
+      (nil? repo)       (cb not-authenticated)
+      :else             (client/query client (list-records-request repo m) :callback cb))
+    val))
+
+(defn list-all-records
+  "All pages of com.atproto.repo.listRecords, collecting :records into a
+  single vector (via atproto.xrpc.client/fetch-all).
+
+  m: as list-records, plus :max-pages to guard unbounded collections."
+  [client {:keys [repo collection max-pages] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))]
+    (cond
+      (nil? collection) (cb (invalid-request ":collection is required."))
+      (nil? repo)       (cb not-authenticated)
+      :else             (xrpc/fetch-all client
+                                        (list-records-request repo m)
+                                        :max-pages max-pages
+                                        :callback cb))
+    val))
+
+#?(:clj
+   (defn record-seq
+     "Lazy, blocking seq of records across listRecords pages (CLJ only; do
+     not use on event-loop threads). m: as list-records. If a page fetch
+     fails, the error map is the final element of the seq."
+     [client {:keys [repo collection] :as m}]
+     (let [repo (or repo (client/did client))]
+       (cond
+         (nil? collection) (list (invalid-request ":collection is required."))
+         (nil? repo)       (list not-authenticated)
+         :else             (mapcat (fn [page]
+                                     (if (:error page)
+                                       [page]
+                                       (:records page)))
+                                   (xrpc/page-seq client (list-records-request repo m)))))))
+
+(def ^:private write-type->lex-type
+  {:create "com.atproto.repo.applyWrites#create"
+   :update "com.atproto.repo.applyWrites#update"
+   :delete "com.atproto.repo.applyWrites#delete"})
+
+(defn- write->op
+  [{:keys [type collection rkey value]}]
+  (when-let [lex-type (write-type->lex-type type)]
+    (cond-> {:$type lex-type}
+      collection (assoc :collection collection)
+      rkey (assoc :rkey rkey)
+      (not= :delete type) (assoc :value value))))
+
+(defn apply-writes
+  "com.atproto.repo.applyWrites.
+
+  m: :writes - vector of plain maps, translated to the $type-tagged
+     com.atproto.repo.applyWrites#create/update/delete unions:
+       {:type :create :collection nsid :rkey (optional) :value record}
+       {:type :update :collection nsid :rkey rkey :value record}
+       {:type :delete :collection nsid :rkey rkey}
+     :repo, :validate?, :swap-commit optional."
+  [client {:keys [writes repo validate? swap-commit] :as m} & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        repo (or repo (client/did client))
+        ops (mapv write->op writes)]
+    (cond
+      (or (empty? ops) (some nil? ops))
+      (cb (invalid-request "Each write requires a :type of :create, :update, or :delete."))
+
+      (nil? repo)
+      (cb not-authenticated)
+
+      :else
+      (client/procedure client
+                        (merge (select-keys m passthrough-keys)
+                               {:nsid "com.atproto.repo.applyWrites"
+                                :body (cond-> {:repo repo
+                                               :writes ops}
+                                        (some? validate?) (assoc :validate validate?)
+                                        swap-commit (assoc :swapCommit swap-commit))})
+                        :callback cb))
+    val))
+
+(defn upload-blob
+  "com.atproto.repo.uploadBlob.
+
+  `blob` is platform bytes (CLJ: byte[], InputStream, or File; CLJS:
+  js/Blob, js/ArrayBuffer, or js/Uint8Array). `encoding` is the blob's MIME
+  type - required on CLJ; on CLJS it defaults to a js/Blob's .-type.
+  The :headers/:timeout/:signal/:max-retries passthrough keys are read from
+  the trailing options.
+
+  Result body: {:blob {:$type \"blob\" :ref ... :mimeType ... :size ...}}
+  (already decoded to atproto data by the data.json interceptor)."
+  [client blob encoding & {:as opts}]
+  (let [[cb val] (i/platform-async opts)
+        encoding #?(:clj encoding
+                    :cljs (or encoding
+                              (when (instance? js/Blob blob)
+                                (not-empty (.-type blob)))))]
+    (if (nil? encoding)
+      (cb (invalid-request "An encoding MIME type is required to upload a blob."))
+      (client/procedure client
+                        (merge (select-keys opts passthrough-keys)
+                               {:nsid "com.atproto.repo.uploadBlob"
+                                :body blob
+                                :encoding encoding})
+                        :callback cb))
+    val))

--- a/src/atproto/runtime/datetime.cljc
+++ b/src/atproto/runtime/datetime.cljc
@@ -1,5 +1,5 @@
 (ns atproto.runtime.datetime
-  #?(:clj (:import [java.time OffsetDateTime]
+  #?(:clj (:import [java.time Instant LocalDateTime OffsetDateTime ZoneOffset]
                    [java.time.temporal ChronoField]
                    [java.time.format DateTimeFormatter DateTimeFormatterBuilder DateTimeParseException SignStyle])))
 
@@ -28,3 +28,89 @@
 (defn current-time-millis
   []
   #?(:clj (System/currentTimeMillis)))
+
+#?(:clj
+   (def ^:private canonical-formatter
+     "Canonical atproto datetime: UTC, millisecond precision, trailing Z."
+     (-> (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss.SSS'Z'")
+         (.withZone ZoneOffset/UTC))))
+
+#?(:clj
+   (def ^:private local-utc-formatter
+     "Local date-time followed by a literal \" UTC\" suffix."
+     (-> (DateTimeFormatterBuilder.)
+         (.append DateTimeFormatter/ISO_LOCAL_DATE_TIME)
+         (.appendLiteral " UTC")
+         (.toFormatter))))
+
+#?(:clj
+   (defn- parse-lenient*
+     "Try parsing a datetime string with each known format; an OffsetDateTime
+     or nil."
+     [s]
+     (or (parse s)
+         (try (-> (LocalDateTime/parse (trim-fraction s) local-utc-formatter)
+                  (.atOffset ZoneOffset/UTC))
+              (catch DateTimeParseException _))
+         (try (OffsetDateTime/parse s DateTimeFormatter/RFC_1123_DATE_TIME)
+              (catch DateTimeParseException _)))))
+
+#?(:clj
+   (defn- valid-atproto-year?
+     "atproto datetimes must format with a 4-digit, non-negative UTC year."
+     [^OffsetDateTime odt]
+     (<= 0 (.getYear (.withOffsetSameInstant odt ZoneOffset/UTC)) 9999)))
+
+(defn current-datetime
+  "Now, as a canonical atproto datetime string (UTC, millisecond precision,
+  trailing Z)."
+  []
+  #?(:clj (.format ^DateTimeFormatter canonical-formatter (Instant/now))
+     :cljs {:error "NotImplemented"
+            :message "current-datetime is not implemented on ClojureScript yet."}))
+
+(defn normalize
+  "Flexible datetime string -> canonical UTC ISO-8601 with millisecond
+  precision (\"...sssZ\").
+
+  Inputs without timezone information are interpreted as UTC. Returns
+  {:error \"InvalidDatetime\" :message ...} when the string cannot be parsed
+  as a datetime or normalizes outside the year 0000-9999 bounds."
+  [s]
+  #?(:clj
+     (let [tz-designator? (and (string? s)
+                               (or (re-find #"[+-]\d\d:?\d\d" s)
+                                   (re-find #"\dZ\b" s)
+                                   ;; timezone abbreviation, eg. "UTC", "GMT", "PST"
+                                   (re-find #"\b[A-Z]{3,4}\b" s)))
+           odt (when (string? s)
+                 (if tz-designator?
+                   ;; an explicit designator: parse as-is
+                   (parse-lenient* s)
+                   ;; no timezone information: interpret as UTC, falling
+                   ;; back to parsing as-is
+                   (or (parse-lenient* (str s "Z"))
+                       (parse-lenient* (str s " UTC"))
+                       (parse-lenient* s))))]
+       (if (and odt (valid-atproto-year? odt))
+         (.format ^DateTimeFormatter canonical-formatter (.toInstant ^OffsetDateTime odt))
+         {:error "InvalidDatetime"
+          :message (str "Datetime did not parse as any timestamp format: " (pr-str s))}))
+     :cljs
+     {:error "NotImplemented"
+      :message "normalize is not implemented on ClojureScript yet."}))
+
+(def epoch-datetime "1970-01-01T00:00:00.000Z")
+
+(defn normalize-or-epoch
+  "Like `normalize` but returns \"1970-01-01T00:00:00.000Z\" instead of an
+  error map."
+  [s]
+  #?(:clj
+     (let [result (normalize s)]
+       (if (:error result)
+         epoch-datetime
+         result))
+     :cljs
+     {:error "NotImplemented"
+      :message "normalize-or-epoch is not implemented on ClojureScript yet."}))

--- a/src/atproto/runtime/http.cljc
+++ b/src/atproto/runtime/http.cljc
@@ -8,9 +8,11 @@
             [atproto.runtime.http.response :as-alias response]
             [atproto.runtime.http.url :as-alias url]
             [atproto.runtime.cast :as cast]
+            [atproto.runtime.retry :as retry]
             #?@(:clj [[org.httpkit.client :as http]]))
-  #?(:clj (:import [java.net URI URL MalformedURLException URLEncoder URLDecoder])
-     :cljs (:import [goog.net EventType XhrIo]
+  #?(:clj (:import [java.net URI URL MalformedURLException URLEncoder URLDecoder]
+                   [org.httpkit.client TimeoutException])
+     :cljs (:import [goog.net ErrorCode EventType XhrIo]
                     [goog Uri])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -122,29 +124,43 @@
        (when fragment (str "#" fragment))))
 
 (defn handle-request
-  "runtime-specific handling of the http request"
+  "runtime-specific handling of the http request
+
+  Honors :timeout (ms), surfacing {:error \"Timeout\"}. On CLJS an aborted
+  request (via the :signal abort signal, see atproto.runtime.retry)
+  surfaces {:error \"Aborted\"}; on CLJ in-flight requests cannot be
+  interrupted and cancellation is cooperative (handled by the callers)."
   [http-request cb]
   #?(:clj
-     (http/request (update http-request :headers stringify-keys)
+     (http/request (-> http-request
+                       (dissoc :signal)
+                       (update :headers stringify-keys))
                    (fn [{:keys [^Throwable error] :as http-response}]
                      (let [http-response (dissoc http-response :opts)]
-                       (cb (if error
+                       (cb (cond
+                             (instance? TimeoutException error)
+                             {:error "Timeout"
+                              :message (.getMessage error)
+                              :ex error}
+
+                             error
                              {:error "HTTPClientError"
                               :message (.getMessage error)
                               :ex error}
-                             http-response)))))
+
+                             :else http-response)))))
 
      :cljs
-     (let [{:keys [method url query-params headers body]} http-request]
+     (let [{:keys [method url query-params headers body timeout signal]} http-request]
        (let [uri (doto (Uri. url)
                    (.setQuery (query-params->query-string query-params)))
              xhr (doto (XhrIo.)
-                   (.setTimeoutInterval 0))]
+                   (.setTimeoutInterval (or timeout 0)))]
          (.listen xhr
                   EventType/COMPLETE
                   (fn [evt]
                     (let [target (.-target evt)
-                          error (not-empty (.getLastError target))
+                          error-code (.getLastErrorCode target)
                           http-response {:status (.getStatus target)
                                          :headers (->> (.getAllResponseHeaders target)
                                                        (str/split-lines)
@@ -159,7 +175,19 @@
                                                                      headers)))
                                                                {}))
                                          :body (.getResponse target)}]
-                      (cb http-response))))
+                      (cond
+                        (= ErrorCode/TIMEOUT error-code)
+                        (cb {:error "Timeout"
+                             :message "The HTTP request timed out."})
+
+                        (= ErrorCode/ABORT error-code)
+                        (cb {:error "Aborted"
+                             :message "The HTTP request was aborted."})
+
+                        :else
+                        (cb http-response)))))
+         (when signal
+           (retry/on-abort! signal #(.abort xhr)))
          (.send xhr
                 uri
                 (name method)

--- a/src/atproto/runtime/retry.cljc
+++ b/src/atproto/runtime/retry.cljc
@@ -1,0 +1,93 @@
+(ns atproto.runtime.retry
+  "Callback-based retry with exponential backoff (ports common-web/retry.ts),
+  plus the cooperative abort signal used for request cancellation."
+  (:require [atproto.xrpc.error :as xrpc-error]))
+
+;; Abort signals
+;;
+;; A signal is an opaque value created by `abort-signal` and tripped (at most
+;; once) by `abort!`. Consumers either poll with `aborted?` or register a
+;; zero-arg listener with `on-abort!`; every listener is invoked exactly once,
+;; immediately if the signal is already aborted.
+
+(defn abort-signal
+  "Create a cooperative cancellation signal."
+  []
+  (atom {:aborted? false :listeners []}))
+
+(defn aborted?
+  "Whether the signal has been aborted. nil signals are never aborted."
+  [signal]
+  (boolean (some-> signal deref :aborted?)))
+
+(defn on-abort!
+  "Register a zero-arg listener invoked exactly once when the signal is
+  aborted (immediately, if it already is)."
+  [signal f]
+  (when signal
+    (let [[prev _] (swap-vals! signal (fn [{:keys [aborted?] :as state}]
+                                        (if aborted?
+                                          state
+                                          (update state :listeners conj f))))]
+      (when (:aborted? prev)
+        (f))
+      nil)))
+
+(defn abort!
+  "Trip the signal, invoking pending listeners. Idempotent."
+  [signal]
+  (when signal
+    (let [[prev _] (swap-vals! signal #(assoc % :aborted? true :listeners []))]
+      (when-not (:aborted? prev)
+        (run! #(%) (:listeners prev)))
+      nil)))
+
+;; Retry
+
+(defn backoff-ms
+  "Exponential backoff with jitter: min(2^n * multiplier, max) ± 15%.
+
+  Defaults multiplier=100, max=1000: ~100, ~200, ~400, ~800, ~1000, ~1000, ..."
+  [n & {:keys [multiplier max] :or {multiplier 100 max 1000}}]
+  (let [ms (min (* (Math/pow 2 n) multiplier) max)
+        delta (* ms 0.15)]
+    (+ ms (- (rand (* 2 delta)) delta))))
+
+(defn schedule
+  "Platform-appropriate delayed invocation of zero-arg `f` after `ms`."
+  [ms f]
+  #?(:clj (future (Thread/sleep (long ms)) (f))
+     :cljs (js/setTimeout f ms))
+  nil)
+
+(defn with-retry
+  "Run async op `f`, a fn of one arg (a callback receiving a result map).
+  If the result is retryable and attempts remain, re-run after backoff;
+  otherwise deliver the result to `cb` (which is called exactly once).
+
+  opts: :max-retries (default 3)
+        :retryable?  (fn [result] boolean; default atproto.xrpc.error/retryable?)
+        :backoff-ms  (fn [attempt] ms; default backoff-ms)
+        :signal      optional abort signal; checked before each attempt,
+                     delivering {:error \"Aborted\"} if set"
+  [f {:keys [max-retries signal] :as opts} cb]
+  (let [max-retries (or max-retries 3)
+        result-retryable? (or (:retryable? opts) xrpc-error/retryable?)
+        backoff (or (:backoff-ms opts) backoff-ms)
+        aborted-result {:error "Aborted" :message "Request aborted."}
+        attempt! (fn attempt! [n]
+                   (if (aborted? signal)
+                     (cb aborted-result)
+                     (f (fn [result]
+                          (cond
+                            (not (and (< n max-retries)
+                                      (result-retryable? result)))
+                            (cb result)
+
+                            (aborted? signal)
+                            (cb aborted-result)
+
+                            :else
+                            (schedule (backoff n) #(attempt! (inc n))))))))]
+    (attempt! 0)
+    nil))

--- a/src/atproto/tid.cljc
+++ b/src/atproto/tid.cljc
@@ -1,27 +1,98 @@
 (ns atproto.tid
   "A TID (timestamp identifier) is a compact string identifier based on an integer timestamp.
 
+  A TID is always exactly 13 characters: 11 characters of sort32-encoded
+  microsecond timestamp followed by 2 characters of sort32-encoded clock-id.
+
   See https://atproto.com/specs/tid"
   (:require [clojure.math :refer [floor random]]
-            [clojure.spec.alpha :as s]
-            [atproto.runtime.datetime :refer [current-time-millis]]
-            #?(:clj [clojure.pprint :refer [cl-format]]
-               :cljs [cljs.pprint :refer [cl-format]])))
+            [clojure.string :as str]
+            [atproto.lexicon.regex :as regex]
+            [atproto.runtime.datetime :refer [current-time-millis]]))
+
+(def ^:const tid-length 13)
 
 (def s32-chars "234567abcdefghijklmnopqrstuvwxyz")
 
-(defn- left-pad
-  [s len ch]
-  (cl-format nil (str "~" len ",'" ch "d") (str s)))
+(defn s32-encode
+  "Encode a non-negative integer as a sort32 string.
 
-(defn- s32-encode
-  [n]
-  (loop [n n
-         s '()]
-    (if (zero? n)
-      (apply str (or (seq s) [\2]))
-      (recur (floor (/ n 32))
-             (cons (.charAt s32-chars (mod n 32)) s)))))
+  With `pad-to`, left-pad the result with \\2 (sort32 zero) to that length."
+  ([n]
+   (loop [n (long n)
+          s '()]
+     (if (zero? n)
+       (apply str (or (seq s) [\2]))
+       (recur (quot n 32)
+              (cons (nth s32-chars (rem n 32)) s)))))
+  ([n pad-to]
+   (let [s (s32-encode n)
+         missing (- pad-to (count s))]
+     (if (pos? missing)
+       (str (apply str (repeat missing \2)) s)
+       s))))
+
+(defn s32-decode
+  "Decode a sort32 string into a long. Return nil on invalid characters."
+  [s]
+  (reduce (fn [acc ch]
+            (if-let [idx (str/index-of s32-chars ch)]
+              (+ (* 32 acc) idx)
+              (reduced nil)))
+          0
+          s))
+
+(defn valid?
+  "Whether `s` is a syntactically valid TID (exactly 13 sort32 characters)."
+  [s]
+  (boolean (and (string? s)
+                (= tid-length (count s))
+                (re-matches regex/tid s))))
+
+(defn parse
+  "Parse a TID string into {:timestamp <epoch microseconds> :clock-id <long>}.
+
+  Return nil if the string is not a valid TID."
+  [s]
+  (when (valid? s)
+    {:timestamp (s32-decode (subs s 0 11))
+     :clock-id (s32-decode (subs s 11 tid-length))}))
+
+(defn timestamp
+  "The epoch microseconds of the TID (long), or nil if invalid."
+  [tid]
+  (:timestamp (parse tid)))
+
+(defn clock-id
+  "The clock-id of the TID (long), or nil if invalid."
+  [tid]
+  (:clock-id (parse tid)))
+
+(defn from-time
+  "Build a TID string from epoch microseconds and a clock-id.
+
+  The timestamp segment is zero-padded to 11 characters and the clock-id
+  to 2, so the result is always exactly 13 characters."
+  [micros clock-id]
+  (str (s32-encode micros 11)
+       (s32-encode clock-id 2)))
+
+(defn compare-tids
+  "Lexicographic TID comparator (= chronological order).
+
+  Negative if `a` is older than `b`, positive if newer, zero if equal."
+  [a b]
+  (compare a b))
+
+(defn newer?
+  "Whether TID `a` is strictly newer than TID `b`."
+  [a b]
+  (pos? (compare-tids a b)))
+
+(defn older?
+  "Whether TID `a` is strictly older than TID `b`."
+  [a b]
+  (neg? (compare-tids a b)))
 
 (def ^:private last-timestamp-ms (atom 0))
 
@@ -35,11 +106,19 @@
                ts
                (+ 1 last-ts))))))
 
-;; 10 bits for the clock-id
-(def ^:private clock-id (floor (* 1024 (random))))
+;; 10 bits for the clock-id, fixed for this process
+(def ^:private local-clock-id (long (floor (* 1024 (random)))))
 
 (defn next-tid
-  "The next monotonically increasing TID."
-  []
-  (str (s32-encode (* 1000 (monotime-ms)))
-       (left-pad (s32-encode clock-id) 2 "2")))
+  "The next monotonically increasing TID.
+
+  With `prev` (a TID string), the result is guaranteed to be strictly newer
+  than `prev`, falling back to prev's timestamp + 1 if the clock has not
+  caught up yet."
+  ([]
+   (from-time (* 1000 (monotime-ms)) local-clock-id))
+  ([prev]
+   (let [tid (next-tid)]
+     (if (or (nil? prev) (newer? tid prev))
+       tid
+       (from-time (inc (timestamp prev)) local-clock-id)))))

--- a/src/atproto/xrpc/client.cljc
+++ b/src/atproto/xrpc/client.cljc
@@ -307,12 +307,16 @@
                           (let [request-headers (merged-headers client
                                                                 headers
                                                                 (when body
-                                                                  {:content-type encoding}))]
+                                                                  {:content-type encoding}))
+                                timeout (or (:timeout request) (:timeout client))
+                                signal (:signal request)]
                             (cond-> {:method :post
                                      :url (url client nsid)}
                               (seq request-headers) (assoc :headers request-headers)
                               params (assoc :query-params (xrpc-params->query-params params))
-                              body (assoc :body body)))))))
+                              body (assoc :body body)
+                              timeout (assoc :timeout timeout)
+                              signal (assoc :signal signal)))))))
    ::i/leave (fn [ctx]
                (update ctx ::i/response handle-xrpc-response))})
 
@@ -322,26 +326,80 @@
    ::i/enter (fn [ctx]
                (update ctx
                        ::i/request
-                       (fn [{:keys [nsid params headers]}]
-                         (let [request-headers (merged-headers client headers nil)]
+                       (fn [{:keys [nsid params headers timeout signal]}]
+                         (let [request-headers (merged-headers client headers nil)
+                               timeout (or timeout (:timeout client))]
                            (cond-> {:method :get
                                     :url (url client nsid)}
                              (seq request-headers) (assoc :headers request-headers)
-                             params (assoc :query-params (xrpc-params->query-params params)))))))
+                             params (assoc :query-params (xrpc-params->query-params params))
+                             timeout (assoc :timeout timeout)
+                             signal (assoc :signal signal))))))
    ::i/leave (fn [ctx]
                (update ctx ::i/response handle-xrpc-response))})
 
+(defn abort-signal
+  "Create a cancellation signal accepted by query/procedure as :signal.
+  Trip it with `abort!`."
+  []
+  (retry/abort-signal))
+
+(defn abort!
+  "Trip the signal. Pending xrpc calls deliver {:error \"Aborted\"} exactly
+  once and, where the platform supports it (CLJS XhrIo), the in-flight HTTP
+  request is aborted. On CLJ the underlying http-kit request cannot be
+  interrupted; its eventual result is discarded."
+  [signal]
+  (retry/abort! signal))
+
+(def ^:private aborted-response
+  {:error "Aborted" :message "Request aborted."})
+
+(defn- signal-interceptor
+  "Replace the response with {:error \"Aborted\"} when the signal has been
+  tripped, checked at chain entry (before the request is sent) and exit."
+  [signal]
+  (let [check (fn [ctx]
+                (if (retry/aborted? signal)
+                  (assoc ctx ::i/response aborted-response)
+                  ctx))]
+    {::i/name ::signal
+     ::i/enter check
+     ::i/leave check}))
+
 (defn- execute-xrpc
-  "Execute the XRPC interceptor chain for the request."
-  [client xrpc-interceptor request opts]
-  (i/execute {::i/request request
-              ::i/queue [(request-validator client)
-                         xrpc-interceptor
-                         (delegate-auth-interceptor client)
-                         atproto-json/client-interceptor
-                         json/client-interceptor
-                         http/client-interceptor]}
-             opts))
+  "Execute the XRPC interceptor chain for the request.
+
+  When the request carries :max-retries (or the client has a default),
+  retryable errors are retried with exponential backoff; the whole chain is
+  re-executed so auth refresh works per attempt. When the request carries a
+  :signal, abort! delivers {:error \"Aborted\"} exactly once (in-flight
+  results are discarded)."
+  [client xrpc-interceptor {:keys [signal] :as request} opts]
+  (let [max-retries (or (:max-retries request) (:max-retries client) 0)
+        ctx {::i/request request
+             ::i/queue (cond->> [(request-validator client)
+                                 xrpc-interceptor
+                                 (delegate-auth-interceptor client)
+                                 atproto-json/client-interceptor
+                                 json/client-interceptor
+                                 http/client-interceptor]
+                         signal (cons (signal-interceptor signal)))}]
+    (if (or (pos? max-retries) signal)
+      (let [[cb val] (i/platform-async opts)
+            delivered? (atom false)
+            deliver! (fn [result]
+                       (when (compare-and-set! delivered? false true)
+                         (cb result)))]
+        (when signal
+          (retry/on-abort! signal #(deliver! aborted-response)))
+        (retry/with-retry (fn [attempt-cb]
+                            (i/execute ctx :callback attempt-cb))
+                          {:max-retries max-retries
+                           :signal signal}
+                          deliver!)
+        val)
+      (i/execute ctx opts))))
 
 (defn procedure
   [client request & {:as opts}]

--- a/src/atproto/xrpc/client.cljc
+++ b/src/atproto/xrpc/client.cljc
@@ -408,3 +408,79 @@
 (defn query
   [client request & {:as opts}]
   (execute-xrpc client (query-interceptor client) request opts))
+
+(defn- no-cursor?
+  [cursor]
+  (or (nil? cursor)
+      (and (string? cursor) (str/blank? cursor))))
+
+(defn fetch-pages
+  "Cursor pagination driver.
+
+  Repeatedly calls `query` with :cursor threaded from each response into the
+  request's :params, invoking (step-fn acc page) per page (a `reduced` acc
+  short-circuits). Stops when the response has no cursor, the page's items
+  are empty, :max-pages is reached, or an error occurs (the error map is
+  then the delivered result). Async like everything else; the deferred value
+  is the final acc.
+
+  opts: :items-fn (default :records), :cursor-fn (default :cursor),
+        :max-pages, plus :channel/:callback/:promise."
+  [client request step-fn init-acc & {:as opts}]
+  (let [items-fn (or (:items-fn opts) :records)
+        cursor-fn (or (:cursor-fn opts) :cursor)
+        max-pages (:max-pages opts)
+        [cb val] (i/platform-async (select-keys opts [:channel :callback :promise]))]
+    (letfn [(fetch! [request acc page-count]
+              (query client request
+                     :callback
+                     (fn [page]
+                       (if (:error page)
+                         (cb page)
+                         (let [result (step-fn acc page)
+                               acc (unreduced result)
+                               cursor (cursor-fn page)
+                               page-count (inc page-count)]
+                           (if (or (reduced? result)
+                                   (no-cursor? cursor)
+                                   (empty? (items-fn page))
+                                   (and max-pages (<= max-pages page-count)))
+                             (cb acc)
+                             (fetch! (assoc-in request [:params :cursor] cursor)
+                                     acc
+                                     page-count)))))))]
+      (fetch! request init-acc 0))
+    val))
+
+(defn fetch-all
+  "fetch-pages collecting (items-fn page) from every page into a single
+  vector. Guard unbounded collections with :max-pages."
+  [client request & {:as opts}]
+  (let [items-fn (or (:items-fn opts) :records)]
+    (fetch-pages client request
+                 (fn [acc page] (into acc (items-fn page)))
+                 []
+                 opts)))
+
+#?(:clj
+   (defn page-seq
+     "Lazy seq of page bodies, paginating like `fetch-pages`; each step blocks
+     on the underlying promise. CLJ-only convenience; do not use on
+     event-loop threads. If a page fetch fails, the error map is the final
+     element of the seq.
+
+     opts: :items-fn (default :records), :cursor-fn (default :cursor)."
+     [client request & {:as opts}]
+     (let [items-fn (or (:items-fn opts) :records)
+           cursor-fn (or (:cursor-fn opts) :cursor)
+           step (fn step [request]
+                  (lazy-seq
+                   (let [page @(query client request)]
+                     (if (:error page)
+                       (list page)
+                       (let [cursor (cursor-fn page)]
+                         (cons page
+                               (when-not (or (no-cursor? cursor)
+                                             (empty? (items-fn page)))
+                                 (step (assoc-in request [:params :cursor] cursor)))))))))]
+       (step request))))

--- a/src/atproto/xrpc/client.cljc
+++ b/src/atproto/xrpc/client.cljc
@@ -6,29 +6,106 @@
             [atproto.runtime.json :as json]
             [atproto.runtime.interceptor :as i]
             [atproto.runtime.cast :as cast]
+            [atproto.runtime.retry :as retry]
             [atproto.data.json :as atproto-json]
+            [atproto.xrpc.error :as xrpc-error]
             [atproto.lexicon :as lexicon]))
 
 ;; TODO:
 ;; - return error for unkown params when validating request?
 ;; - should we only serialize known parameters if lexicon loaded?
-;; - productionize (error handling, timeout, retry...)
-;; - pagination w/ cursor
-;; - consider bubbling up server error in the response map
+
+(def ^:private service-proxy-regex
+  ;; "<did>#<service-identifier>", e.g. "did:web:api.bsky.app#bsky_appview"
+  #"^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]#[a-zA-Z0-9_]+$")
+
+(s/def ::service-proxy
+  (s/and string? #(re-matches service-proxy-regex %)))
 
 (defn init
   "Initialize a new XRPC client and return it.
 
-  config keys: :service, :session, :validate-requests?. The returned client
-  also carries ::refresh-state (atom) used to single-flight token refreshes.
-  Throws if neither :service nor :session is provided."
-  [{:keys [service session validate-requests?] :as config}]
-  (if (and (not service) (not session))
+  config keys:
+  :service            Base URL of the XRPC service.
+  :session            Session to authenticate requests with.
+  :validate-requests? Validate requests against their lexicon before sending.
+  :headers            Map of default headers for every request (lowercase
+                      keyword keys).
+  :service-proxy      \"<did>#<service-id>\" emitted as the atproto-proxy
+                      header (a per-request atproto-proxy header wins).
+  :labelers           Coll of labeler DIDs, or {:did ... :redact? true} maps,
+                      emitted as the atproto-accept-labelers header.
+  :timeout            Default per-request timeout in ms.
+  :max-retries        Default retry count for retryable errors (default 0 = off).
+
+  The returned client also carries ::refresh-state (atom) used to
+  single-flight token refreshes. Throws if neither :service nor :session is
+  provided, or if :service-proxy is malformed."
+  [{:keys [service session validate-requests?
+           headers service-proxy labelers timeout max-retries] :as config}]
+  (cond
+    (and (not service) (not session))
     (throw (ex-info "A service or a session is required." config))
-    {:service (or service (:pds session))
-     :session (when session (atom session))
-     :validate-requests? (boolean validate-requests?)
-     ::refresh-state (atom nil)}))
+
+    (and service-proxy (not (s/valid? ::service-proxy service-proxy)))
+    (throw (ex-info "Invalid :service-proxy; expected \"<did>#<service-id>\"."
+                    {:service-proxy service-proxy}))
+
+    :else
+    (cond-> {:service (or service (:pds session))
+             :session (when session (atom session))
+             :validate-requests? (boolean validate-requests?)
+             ::refresh-state (atom nil)}
+      headers       (assoc :headers headers)
+      service-proxy (assoc :service-proxy service-proxy)
+      labelers      (assoc :labelers labelers)
+      timeout       (assoc :timeout timeout)
+      max-retries   (assoc :max-retries max-retries))))
+
+(defn with-service-proxy
+  "Return a client that routes requests via the given service, e.g.
+  \"did:web:api.bsky.app#bsky_appview\" (emitted as the atproto-proxy header)."
+  [client service]
+  (if (s/valid? ::service-proxy service)
+    (assoc client :service-proxy service)
+    (throw (ex-info "Invalid :service-proxy; expected \"<did>#<service-id>\"."
+                    {:service-proxy service}))))
+
+(defn with-labelers
+  "Return a client that sends the given labelers (a coll of labeler DIDs, or
+  {:did ... :redact? true} maps) as the atproto-accept-labelers header."
+  [client labelers]
+  (assoc client :labelers labelers))
+
+(defn- labelers-header-value
+  [labelers]
+  (->> labelers
+       (map (fn [labeler]
+              (if (map? labeler)
+                (str (:did labeler) (when (:redact? labeler) ";redact"))
+                labeler)))
+       (str/join ", ")))
+
+(defn- merged-headers
+  "Merge the headers for an outgoing request.
+
+  Precedence: client defaults < proxy/labelers < per-request headers <
+  computed headers. The atproto-proxy header is only set from the client when
+  absent per-request; atproto-accept-labelers merges the client's labelers
+  with any per-request value."
+  [{:keys [headers service-proxy labelers]} request-headers computed-headers]
+  (let [merged (merge headers request-headers)
+        merged (if (and service-proxy (not (:atproto-proxy merged)))
+                 (assoc merged :atproto-proxy service-proxy)
+                 merged)
+        merged (if (seq labelers)
+                 (assoc merged :atproto-accept-labelers
+                        (->> [(labelers-header-value labelers)
+                              (some-> (:atproto-accept-labelers merged) str/trim)]
+                             (remove str/blank?)
+                             (str/join ", ")))
+                 merged)]
+    (merge merged computed-headers)))
 
 (defn request-validator
   [{:keys [validate-requests?]}]
@@ -37,8 +114,8 @@
                (let [spec (binding [lexicon/*schema-validate* validate-requests?]
                             (lexicon/request-spec-key (:nsid request)))]
                  (if (not (s/valid? spec request))
-                   (throw (ex-info "Invalid Request"
-                                   {:explain-data (s/explain-data spec request)}))
+                   (assoc ctx ::i/response (xrpc-error/invalid-request
+                                            (s/explain-data spec request)))
                    ctx)))})
 
 (defprotocol Session
@@ -179,43 +256,65 @@
           {}
           params))
 
+(defn- with-headers-meta
+  "Attach the response headers as ::headers metadata when the body supports
+  metadata (maps/collections); other bodies are returned untouched."
+  [body headers]
+  (if #?(:clj (instance? clojure.lang.IObj body)
+         :cljs (implements? IWithMeta body))
+    (vary-meta body assoc ::headers headers)
+    body))
+
+(defn response-headers
+  "The HTTP response headers of a successful XRPC call, read from the
+  body's metadata (nil for bodies that do not support metadata)."
+  [body]
+  (::headers (meta body)))
+
 (defn- handle-xrpc-response
-  [{:keys [error status body] :as http-response}]
+  [{:keys [error status headers body] :as http-response}]
   (cond
-    error                  http-response
-    (http/success? status) (:body http-response)
-    (:error body)          (:body http-response)
-    :else                  (http/error-map http-response)))
+    ;; transport-level failures are retryable; other error maps reaching the
+    ;; leave chain (auth refresh failures, Aborted) pass through unchanged
+    error                  (case error
+                             ("HTTPClientError" "Timeout") (xrpc-error/network-error http-response)
+                             http-response)
+    (http/success? status) (with-headers-meta body headers)
+    :else                  (xrpc-error/http-error http-response)))
 
 (defn- procedure-interceptor
   [client]
   {::i/name ::procedure
-   ::i/enter (fn [ctx]
-               (update ctx
-                       ::i/request
-                       (fn [{:keys [nsid params encoding body] :as request}]
-                         (let [encoding (or encoding
-                                            (when (coll? body) "application/json"))]
-                           (when (and body (not encoding))
-                             (throw (ex-info "Missing encoding" request)))
-                           (cond-> {:method :post
-                                    :url (url client nsid)}
-                             params (assoc :query-params (xrpc-params->query-params params))
-                             body (assoc :body body
-                                         :headers {:content-type encoding}))))))
+   ::i/enter (fn [{:keys [::i/request] :as ctx}]
+               (let [{:keys [nsid params encoding body headers]} request
+                     encoding (or encoding
+                                  (when (coll? body) "application/json"))]
+                 (cond
+                   (and body (not encoding))
+                   (assoc ctx ::i/response
+                          {:error "InvalidRequest"
+                           :message "Missing :encoding for the request body."
+                           :retryable? false})
+
+                   (and body (:content-type headers))
+                   (assoc ctx ::i/response
+                          {:error "InvalidRequest"
+                           :message "Do not set a content-type header; use :encoding to specify the body MIME type."
+                           :retryable? false})
+
+                   :else
+                   (assoc ctx ::i/request
+                          (let [request-headers (merged-headers client
+                                                                headers
+                                                                (when body
+                                                                  {:content-type encoding}))]
+                            (cond-> {:method :post
+                                     :url (url client nsid)}
+                              (seq request-headers) (assoc :headers request-headers)
+                              params (assoc :query-params (xrpc-params->query-params params))
+                              body (assoc :body body)))))))
    ::i/leave (fn [ctx]
                (update ctx ::i/response handle-xrpc-response))})
-
-(defn procedure
-  [{:keys [session] :as client} request & {:as opts}]
-  (i/execute {::i/request request
-              ::i/queue [(request-validator client)
-                         (procedure-interceptor client)
-                         (delegate-auth-interceptor client)
-                         atproto-json/client-interceptor
-                         json/client-interceptor
-                         http/client-interceptor]}
-             opts))
 
 (defn- query-interceptor
   [client]
@@ -223,20 +322,31 @@
    ::i/enter (fn [ctx]
                (update ctx
                        ::i/request
-                       (fn [{:keys [nsid params]}]
-                         (cond-> {:method :get
-                                  :url (url client nsid)}
-                           params (assoc :query-params (xrpc-params->query-params params))))))
+                       (fn [{:keys [nsid params headers]}]
+                         (let [request-headers (merged-headers client headers nil)]
+                           (cond-> {:method :get
+                                    :url (url client nsid)}
+                             (seq request-headers) (assoc :headers request-headers)
+                             params (assoc :query-params (xrpc-params->query-params params)))))))
    ::i/leave (fn [ctx]
                (update ctx ::i/response handle-xrpc-response))})
 
-(defn query
-  [{:keys [session] :as client} request & {:as opts}]
+(defn- execute-xrpc
+  "Execute the XRPC interceptor chain for the request."
+  [client xrpc-interceptor request opts]
   (i/execute {::i/request request
               ::i/queue [(request-validator client)
-                         (query-interceptor client)
+                         xrpc-interceptor
                          (delegate-auth-interceptor client)
                          atproto-json/client-interceptor
                          json/client-interceptor
                          http/client-interceptor]}
              opts))
+
+(defn procedure
+  [client request & {:as opts}]
+  (execute-xrpc client (procedure-interceptor client) request opts))
+
+(defn query
+  [client request & {:as opts}]
+  (execute-xrpc client (query-interceptor client) request opts))

--- a/src/atproto/xrpc/error.cljc
+++ b/src/atproto/xrpc/error.cljc
@@ -1,0 +1,91 @@
+(ns atproto.xrpc.error
+  "Typed error taxonomy for XRPC responses, mirroring @atproto/lex-client errors.
+
+  All XRPC failures are error maps of the shape:
+
+  {:error <string> :message <string>? :status <int>? :headers <map>?
+   :retryable? <boolean> :http-response <map>?}
+
+  Server-provided JSON :error names are always preserved verbatim; the
+  status-derived name is only used when the response body does not carry a
+  valid {\"error\": ...} payload.")
+
+(def status->error-name
+  "HTTP status -> canonical XRPC error name (used when the response body
+  does not carry a valid {\"error\": ...} payload)."
+  {400 "InvalidRequest"
+   401 "AuthenticationRequired"
+   403 "Forbidden"
+   404 "XRPCNotSupported"
+   406 "NotAcceptable"
+   413 "PayloadTooLarge"
+   415 "UnsupportedMediaType"
+   429 "RateLimitExceeded"
+   500 "InternalServerError"
+   501 "MethodNotImplemented"
+   502 "UpstreamFailure"
+   503 "NotEnoughResources"
+   504 "UpstreamTimeout"})
+
+(def retryable-statuses
+  "HTTP statuses that indicate a transient error that may succeed on retry."
+  #{408 425 429 500 502 503 504 522 524})
+
+(defn derived-error-name
+  "The canonical XRPC error name for an HTTP status without a valid error
+  payload: the status->error-name entry, else InvalidRequest for unknown 4xx,
+  UpstreamFailure for unknown 5xx, and XRPCNotSupported for 1xx/3xx."
+  [status]
+  (or (status->error-name status)
+      (cond
+        (and (number? status) (<= 500 status 599)) "UpstreamFailure"
+        (and (number? status) (<= 400 status 499)) "InvalidRequest"
+        :else "XRPCNotSupported")))
+
+(defn retryable-status?
+  [status]
+  (boolean (and (not= 401 status)
+                (contains? retryable-statuses status))))
+
+(defn- error-payload
+  "The response body when it is a valid XRPC error payload, else nil."
+  [body]
+  (when (and (map? body) (string? (:error body)))
+    body))
+
+(defn http-error
+  "Build an error map from a non-2xx XRPC HTTP response.
+
+  The body's :error/:message win when the body is a JSON error payload;
+  otherwise the error name is derived from the status. The raw response is
+  kept under :http-response."
+  [{:keys [status headers body] :as http-response}]
+  (let [payload (error-payload body)]
+    (cond-> {:error (or (:error payload) (derived-error-name status))
+             :message (or (:message payload)
+                          (str "XRPC request failed with HTTP status " status "."))
+             :status status
+             :retryable? (retryable-status? status)
+             :http-response http-response}
+      headers (assoc :headers headers))))
+
+(defn network-error
+  "Wrap a runtime transport failure ({:error \"HTTPClientError\"/\"Timeout\"/...})
+  as a retryable XRPC error map (no :status)."
+  [err]
+  (-> err
+      (update :error #(or % "HTTPClientError"))
+      (assoc :retryable? true)))
+
+(defn invalid-request
+  "Error map for a client-side request validation failure (never retryable)."
+  [explain-data]
+  {:error "InvalidRequest"
+   :message "The request is not valid for this lexicon."
+   :retryable? false
+   :explain-data explain-data})
+
+(defn retryable?
+  "True if the error map is marked retryable."
+  [error-map]
+  (boolean (:retryable? error-map)))

--- a/test/atproto/at_uri_test.cljc
+++ b/test/atproto/at_uri_test.cljc
@@ -1,0 +1,89 @@
+(ns atproto.at-uri-test
+  (:require #?@(:clj [[clojure.test :refer :all]
+                      [clojure.java.io :as io]]
+                :cljs [[cljs.test :refer :all]])
+            [clojure.string :as str]
+            [atproto.at-uri :as at-uri])
+  #?(:cljs (:require-macros [atproto.at-uri-test :refer [interop-test-cases]])))
+
+#?(:clj
+   (defmacro interop-test-cases
+     "Return the test cases from the file at `path` in the interop test file directory.
+
+      Can be called from ClojureScript to inline the test cases."
+     [path]
+     (->> (slurp (io/resource (str "interop-test-files/" path)))
+          (str/split-lines)
+          (remove #(or (str/blank? %)
+                       (str/starts-with? % "#")))
+          (into []))))
+
+(deftest interop-fixtures-test
+  (doseq [s (interop-test-cases "syntax/aturi_syntax_valid.txt")]
+    (is (at-uri/valid? s) (str "expected valid: " s))
+    (let [parsed (at-uri/parse s)]
+      (is (some? parsed) (str "expected parseable: " s))
+      ;; fixture URIs are canonical: make round-trips them exactly
+      (is (= s (at-uri/make parsed)) (str "expected round-trip: " s))))
+  (doseq [s (interop-test-cases "syntax/aturi_syntax_invalid.txt")]
+    (is (not (at-uri/valid? s)) (str "expected invalid: " s))
+    (is (nil? (at-uri/parse s)) (str "expected unparseable: " s))))
+
+(deftest parse-test
+  (is (= {:authority "did:plc:asdf123"}
+         (at-uri/parse "at://did:plc:asdf123")))
+  (is (= {:authority "user.bsky.social"}
+         (at-uri/parse "at://user.bsky.social")))
+  (is (= {:authority "did:plc:asdf123"
+          :collection "app.bsky.feed.post"}
+         (at-uri/parse "at://did:plc:asdf123/app.bsky.feed.post")))
+  (is (= {:authority "did:plc:asdf123"
+          :collection "app.bsky.feed.post"
+          :rkey "3jzfcijpj2z2a"}
+         (at-uri/parse "at://did:plc:asdf123/app.bsky.feed.post/3jzfcijpj2z2a")))
+  ;; not a string / garbage
+  (is (nil? (at-uri/parse nil)))
+  (is (nil? (at-uri/parse 42)))
+  (is (nil? (at-uri/parse "")))
+  (is (nil? (at-uri/parse "https://example.com")))
+  ;; invalid segments are rejected even when the shape matches
+  (is (nil? (at-uri/parse "at://name")))
+  (is (nil? (at-uri/parse "at://did:plc:asdf123/not-an-nsid/rkey")))
+  (is (nil? (at-uri/parse "at://did:plc:asdf123/app.bsky.feed.post/..")))
+  ;; 8KB length cap
+  (is (nil? (at-uri/parse (str "at://did:plc:asdf123/app.bsky.feed.post/"
+                               (apply str (repeat (* 8 1024) "o")))))))
+
+(deftest accessors-test
+  (let [uri "at://did:plc:asdf123/app.bsky.feed.post/3jzfcijpj2z2a"]
+    (is (= "did:plc:asdf123" (at-uri/authority uri)))
+    (is (= "app.bsky.feed.post" (at-uri/collection uri)))
+    (is (= "3jzfcijpj2z2a" (at-uri/rkey uri)))
+    (is (nil? (at-uri/fragment uri)))
+    ;; accessors also accept a parsed map
+    (let [parsed (at-uri/parse uri)]
+      (is (= "did:plc:asdf123" (at-uri/authority parsed)))
+      (is (= "app.bsky.feed.post" (at-uri/collection parsed)))
+      (is (= "3jzfcijpj2z2a" (at-uri/rkey parsed)))))
+  (is (nil? (at-uri/collection "at://did:plc:asdf123")))
+  (is (nil? (at-uri/rkey "at://did:plc:asdf123/app.bsky.feed.post")))
+  (is (nil? (at-uri/authority "not-a-uri"))))
+
+(deftest make-test
+  (is (= "at://did:plc:asdf123"
+         (at-uri/make "did:plc:asdf123")))
+  (is (= "at://did:plc:asdf123/app.bsky.feed.post"
+         (at-uri/make "did:plc:asdf123" "app.bsky.feed.post")))
+  (is (= "at://did:plc:asdf123/app.bsky.feed.post/3jzfcijpj2z2a"
+         (at-uri/make "did:plc:asdf123" "app.bsky.feed.post" "3jzfcijpj2z2a")))
+  (is (= "at://did:plc:asdf123/app.bsky.feed.post/3jzfcijpj2z2a"
+         (at-uri/make {:authority "did:plc:asdf123"
+                       :collection "app.bsky.feed.post"
+                       :rkey "3jzfcijpj2z2a"})))
+  ;; bad inputs return error maps
+  (is (= "InvalidAtUri" (:error (at-uri/make "name"))))
+  (is (= "InvalidAtUri" (:error (at-uri/make nil))))
+  (is (= "InvalidAtUri" (:error (at-uri/make "did:plc:asdf123" "not-an-nsid"))))
+  (is (= "InvalidAtUri" (:error (at-uri/make "did:plc:asdf123" "app.bsky.feed.post" ".."))))
+  (is (= "InvalidAtUri" (:error (at-uri/make {:authority "did:plc:asdf123"
+                                              :rkey "3jzfcijpj2z2a"})))))

--- a/test/atproto/client/repo_test.cljc
+++ b/test/atproto/client/repo_test.cljc
@@ -1,0 +1,307 @@
+(ns atproto.client.repo-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [atproto.runtime.interceptor :as i]
+            [atproto.runtime.http :as http]
+            [atproto.runtime.json :as json]
+            [atproto.test-support.http :as fake-http]
+            [atproto.xrpc.client :as xrpc]
+            [atproto.client.repo :as repo]))
+
+(defn- did-session
+  "A no-op Session carrying a DID (implemented via metadata)."
+  [did]
+  (with-meta
+    {:did did :pds "https://pds.test"}
+    {`xrpc/auth-interceptor
+     (fn [_] {::i/name ::noop-auth
+              ::i/enter identity})
+     `xrpc/refresh-token
+     (fn [_ cb] (cb {:error "TokenRefreshError"}))}))
+
+(defn- authed-client
+  []
+  (xrpc/init {:session (did-session "did:plc:tester")}))
+
+(defn- anon-client
+  []
+  (xrpc/init {:service "https://pds.test"}))
+
+(defn- sent
+  "The nsid, decoded JSON body, and params of a captured request."
+  [request]
+  {:nsid (last (clojure.string/split (:url request) #"/"))
+   :method (:method request)
+   :body (some-> (:body request) json/read-str)
+   :params (:query-params request)})
+
+(def ^:private post-record
+  {:$type "app.bsky.feed.post" :text "hello"})
+
+#?(:clj
+   (deftest create-record-test
+     ;; collection from $type, repo from the session DID
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response
+                                         {:uri "at://did:plc:tester/app.bsky.feed.post/3jzfcijpj2z2a"
+                                          :cid "bafyfake"})])]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (repo/create-record (authed-client) {:record post-record})
+                           1000 ::timeout)]
+           (is (= "bafyfake" (:cid resp)))
+           (let [{:keys [nsid method body]} (sent (first @requests))]
+             (is (= "com.atproto.repo.createRecord" nsid))
+             (is (= :post method))
+             (is (= {:repo "did:plc:tester"
+                     :collection "app.bsky.feed.post"
+                     :record post-record}
+                    body))))))
+     ;; explicit args + swap-commit/validate?/rkey passthrough
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:uri "u" :cid "c"})])]
+       (with-redefs [http/handle-request handler]
+         (deref (repo/create-record (anon-client)
+                                    {:record post-record
+                                     :repo "did:plc:other"
+                                     :collection "com.example.custom"
+                                     :rkey "3jzfcijpj2z2a"
+                                     :validate? false
+                                     :swap-commit "bafycommit"})
+                1000 ::timeout)
+         (let [{:keys [body]} (sent (first @requests))]
+           (is (= "did:plc:other" (:repo body)))
+           (is (= "com.example.custom" (:collection body)))
+           (is (= "3jzfcijpj2z2a" (:rkey body)))
+           (is (false? (:validate body)))
+           (is (= "bafycommit" (:swapCommit body))))))
+     ;; errors
+     (is (= "NotAuthenticated"
+            (:error (deref (repo/create-record (anon-client) {:record post-record})
+                           1000 ::timeout))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/create-record (authed-client) {})
+                           1000 ::timeout))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/create-record (authed-client) {:record {:text "no type"}})
+                           1000 ::timeout))))))
+
+#?(:clj
+   (deftest get-record-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response
+                                         {:uri "u" :cid "c" :value post-record})])]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (repo/get-record (authed-client)
+                                            {:collection "app.bsky.feed.post"
+                                             :rkey "3jzfcijpj2z2a"
+                                             :cid "bafyrecord"})
+                           1000 ::timeout)]
+           (is (= post-record (:value resp)))
+           (let [{:keys [nsid method params]} (sent (first @requests))]
+             (is (= "com.atproto.repo.getRecord" nsid))
+             (is (= :get method))
+             (is (= {:repo "did:plc:tester"
+                     :collection "app.bsky.feed.post"
+                     :rkey "3jzfcijpj2z2a"
+                     :cid "bafyrecord"}
+                    params))))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/get-record (authed-client) {:collection "app.bsky.feed.post"})
+                           1000 ::timeout))))
+     (is (= "NotAuthenticated"
+            (:error (deref (repo/get-record (anon-client) {:collection "app.bsky.feed.post"
+                                                           :rkey "x"})
+                           1000 ::timeout))))))
+
+#?(:clj
+   (deftest put-record-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:uri "u" :cid "c"})])]
+       (with-redefs [http/handle-request handler]
+         (deref (repo/put-record (authed-client)
+                                 {:record post-record
+                                  :rkey "3jzfcijpj2z2a"
+                                  :validate? true
+                                  :swap-commit "bafycommit"
+                                  :swap-record "bafyrecord"})
+                1000 ::timeout)
+         (let [{:keys [nsid body]} (sent (first @requests))]
+           (is (= "com.atproto.repo.putRecord" nsid))
+           (is (= {:repo "did:plc:tester"
+                   :collection "app.bsky.feed.post"
+                   :rkey "3jzfcijpj2z2a"
+                   :record post-record
+                   :validate true
+                   :swapCommit "bafycommit"
+                   :swapRecord "bafyrecord"}
+                  body)))))
+     ;; an explicit nil :swap-record asserts the record does not exist yet
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:uri "u" :cid "c"})])]
+       (with-redefs [http/handle-request handler]
+         (deref (repo/put-record (authed-client)
+                                 {:record post-record
+                                  :rkey "3jzfcijpj2z2a"
+                                  :swap-record nil})
+                1000 ::timeout)
+         (let [{:keys [body]} (sent (first @requests))]
+           (is (contains? body :swapRecord))
+           (is (nil? (:swapRecord body))))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/put-record (authed-client) {:record post-record})
+                           1000 ::timeout))))))
+
+#?(:clj
+   (deftest delete-record-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {})])]
+       (with-redefs [http/handle-request handler]
+         (deref (repo/delete-record (authed-client)
+                                    {:collection "app.bsky.feed.post"
+                                     :rkey "3jzfcijpj2z2a"
+                                     :swap-commit "bafycommit"
+                                     :swap-record "bafyrecord"})
+                1000 ::timeout)
+         (let [{:keys [nsid body]} (sent (first @requests))]
+           (is (= "com.atproto.repo.deleteRecord" nsid))
+           (is (= {:repo "did:plc:tester"
+                   :collection "app.bsky.feed.post"
+                   :rkey "3jzfcijpj2z2a"
+                   :swapCommit "bafycommit"
+                   :swapRecord "bafyrecord"}
+                  body)))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/delete-record (authed-client) {:rkey "x"})
+                           1000 ::timeout))))))
+
+(defn- record-page
+  ([records] (record-page records nil))
+  ([records cursor]
+   (fake-http/json-response (cond-> {:records records}
+                              cursor (assoc :cursor cursor)))))
+
+#?(:clj
+   (deftest list-records-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [{:uri "u" :cid "c" :value post-record}] "next")])]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (repo/list-records (authed-client)
+                                              {:collection "app.bsky.feed.post"
+                                               :limit 10
+                                               :cursor "prev"
+                                               :reverse true})
+                           1000 ::timeout)]
+           (is (= "next" (:cursor resp)))
+           (is (= 1 (count (:records resp))))
+           (let [{:keys [nsid method params]} (sent (first @requests))]
+             (is (= "com.atproto.repo.listRecords" nsid))
+             (is (= :get method))
+             (is (= {:repo "did:plc:tester"
+                     :collection "app.bsky.feed.post"
+                     :limit "10"
+                     :cursor "prev"
+                     :reverse "true"}
+                    params))))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/list-records (authed-client) {})
+                           1000 ::timeout))))))
+
+#?(:clj
+   (deftest list-all-records-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [{:uri "1"} {:uri "2"}] "a")
+                                        (record-page [{:uri "3"}])])]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (repo/list-all-records (authed-client)
+                                                  {:collection "app.bsky.feed.post"})
+                           1000 ::timeout)]
+           (is (= [{:uri "1"} {:uri "2"} {:uri "3"}] resp))
+           (is (= 2 (count @requests)))
+           (is (= "a" (get-in (second @requests) [:query-params :cursor]))))))
+     ;; :max-pages guard
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 5 (record-page [{:uri "x"}] "more")))]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (repo/list-all-records (authed-client)
+                                                  {:collection "app.bsky.feed.post"
+                                                   :max-pages 2})
+                           1000 ::timeout)]
+           (is (= 2 (count resp)))
+           (is (= 2 (count @requests))))))))
+
+#?(:clj
+   (deftest record-seq-test
+     (let [{:keys [handler]} (fake-http/scripted
+                              [(record-page [{:uri "1"} {:uri "2"}] "a")
+                               (record-page [{:uri "3"}])])]
+       (with-redefs [http/handle-request handler]
+         (is (= [{:uri "1"} {:uri "2"} {:uri "3"}]
+                (vec (repo/record-seq (authed-client) {:collection "app.bsky.feed.post"}))))))
+     (is (= "NotAuthenticated"
+            (:error (first (repo/record-seq (anon-client) {:collection "app.bsky.feed.post"})))))))
+
+#?(:clj
+   (deftest apply-writes-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:results []})])]
+       (with-redefs [http/handle-request handler]
+         (deref (repo/apply-writes (authed-client)
+                                   {:writes [{:type :create
+                                              :collection "app.bsky.feed.post"
+                                              :value post-record}
+                                             {:type :update
+                                              :collection "app.bsky.feed.post"
+                                              :rkey "3jzfcijpj2z2a"
+                                              :value post-record}
+                                             {:type :delete
+                                              :collection "app.bsky.feed.post"
+                                              :rkey "3jzfcijpj2z2b"}]
+                                    :validate? true
+                                    :swap-commit "bafycommit"})
+                1000 ::timeout)
+         (let [{:keys [nsid body]} (sent (first @requests))]
+           (is (= "com.atproto.repo.applyWrites" nsid))
+           (is (= "did:plc:tester" (:repo body)))
+           (is (true? (:validate body)))
+           (is (= "bafycommit" (:swapCommit body)))
+           (is (= [{:$type "com.atproto.repo.applyWrites#create"
+                    :collection "app.bsky.feed.post"
+                    :value post-record}
+                   {:$type "com.atproto.repo.applyWrites#update"
+                    :collection "app.bsky.feed.post"
+                    :rkey "3jzfcijpj2z2a"
+                    :value post-record}
+                   {:$type "com.atproto.repo.applyWrites#delete"
+                    :collection "app.bsky.feed.post"
+                    :rkey "3jzfcijpj2z2b"}]
+                  (:writes body))))))
+     ;; unknown write types are rejected
+     (is (= "InvalidRequest"
+            (:error (deref (repo/apply-writes (authed-client)
+                                              {:writes [{:type :upsert :collection "c" :rkey "r"}]})
+                           1000 ::timeout))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/apply-writes (authed-client) {:writes []})
+                           1000 ::timeout))))))
+
+#?(:clj
+   (deftest upload-blob-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response
+                                         {:blob {:$type "blob"
+                                                 :ref {:$link "bafkfake"}
+                                                 :mimeType "image/png"
+                                                 :size 3}})])
+           blob (byte-array [1 2 3])]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (repo/upload-blob (authed-client) blob "image/png")
+                           1000 ::timeout)]
+           (is (= "image/png" (get-in resp [:blob :mimeType])))
+           (let [request (first @requests)]
+             (is (clojure.string/ends-with? (:url request) "/xrpc/com.atproto.repo.uploadBlob"))
+             ;; the bytes reach the wire untouched, with the encoding as content-type
+             (is (identical? blob (:body request)))
+             (is (= "image/png" (get-in request [:headers :content-type])))))))
+     (is (= "InvalidRequest"
+            (:error (deref (repo/upload-blob (authed-client) (byte-array [1]) nil)
+                           1000 ::timeout))))))

--- a/test/atproto/runtime/datetime_test.cljc
+++ b/test/atproto/runtime/datetime_test.cljc
@@ -1,0 +1,75 @@
+(ns atproto.runtime.datetime-test
+  (:require #?@(:clj [[clojure.test :refer :all]
+                      [clojure.java.io :as io]]
+                :cljs [[cljs.test :refer :all]])
+            [clojure.string :as str]
+            [atproto.lexicon.regex :as regex]
+            [atproto.runtime.datetime :as datetime])
+  #?(:cljs (:require-macros [atproto.runtime.datetime-test :refer [interop-test-cases]])))
+
+#?(:clj
+   (defmacro interop-test-cases
+     "Return the test cases from the file at `path` in the interop test file directory.
+
+      Can be called from ClojureScript to inline the test cases."
+     [path]
+     (->> (slurp (io/resource (str "interop-test-files/" path)))
+          (str/split-lines)
+          (remove #(or (str/blank? %)
+                       (str/starts-with? % "#")))
+          (into []))))
+
+;; The :cljs bodies are owned by WS-10; these tests are CLJ-only until then.
+
+#?(:clj
+   (deftest normalize-interop-fixtures-test
+     (doseq [s (interop-test-cases "syntax/datetime_syntax_valid.txt")]
+       (let [normalized (datetime/normalize s)]
+         (is (string? normalized) (str "expected to normalize: " s " got " (pr-str normalized)))
+         (when (string? normalized)
+           (is (re-matches regex/rfc3339 normalized))
+           ;; canonical form: UTC millisecond precision with trailing Z
+           (is (re-matches #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z" normalized)))))
+     ;; syntactically plausible but semantically invalid datetimes must error
+     (doseq [s (interop-test-cases "syntax/datetime_parse_invalid.txt")]
+       (is (= "InvalidDatetime" (:error (datetime/normalize s)))
+           (str "expected normalize to fail: " s)))))
+
+#?(:clj
+   (deftest normalize-test
+     ;; canonical inputs round-trip
+     (is (= "1985-04-12T23:20:50.123Z" (datetime/normalize "1985-04-12T23:20:50.123Z")))
+     ;; offsets are normalized to UTC
+     (is (= "1985-04-13T06:20:50.123Z" (datetime/normalize "1985-04-12T23:20:50.123-07:00")))
+     ;; fractional seconds are truncated to millisecond precision
+     (is (= "1985-04-12T23:20:50.123Z" (datetime/normalize "1985-04-12T23:20:50.123456789Z")))
+     (is (= "1985-04-12T23:20:50.000Z" (datetime/normalize "1985-04-12T23:20:50Z")))
+     ;; missing timezone is interpreted as UTC
+     (is (= "1985-04-12T23:20:50.000Z" (datetime/normalize "1985-04-12T23:20:50")))
+     (is (= "1985-04-12T23:20:50.123Z" (datetime/normalize "1985-04-12T23:20:50.123")))
+     ;; explicit "UTC" timezone abbreviation
+     (is (= "1985-04-12T23:20:50.000Z" (datetime/normalize "1985-04-12T23:20:50 UTC")))
+     ;; RFC-1123
+     (is (= "2008-06-03T11:05:30.000Z" (datetime/normalize "Tue, 3 Jun 2008 11:05:30 GMT")))
+     ;; unparseable input
+     (is (= "InvalidDatetime" (:error (datetime/normalize "blah"))))
+     (is (= "InvalidDatetime" (:error (datetime/normalize ""))))
+     (is (= "InvalidDatetime" (:error (datetime/normalize nil))))
+     ;; year bounds (0000-9999, evaluated in UTC)
+     (is (= "InvalidDatetime" (:error (datetime/normalize "+10000-01-01T00:00:00Z"))))
+     (is (= "InvalidDatetime" (:error (datetime/normalize "9999-12-31T23:30:00-05:00"))))
+     (is (= "0000-01-01T00:00:00.000Z" (datetime/normalize "0000-01-01T00:00:00Z")))))
+
+#?(:clj
+   (deftest normalize-or-epoch-test
+     (is (= "1985-04-12T23:20:50.123Z" (datetime/normalize-or-epoch "1985-04-12T23:20:50.123Z")))
+     (is (= "1970-01-01T00:00:00.000Z" (datetime/normalize-or-epoch "blah")))
+     (is (= "1970-01-01T00:00:00.000Z" (datetime/normalize-or-epoch nil)))))
+
+#?(:clj
+   (deftest current-datetime-test
+     (let [now (datetime/current-datetime)]
+       (is (re-matches #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z" now))
+       (is (re-matches regex/rfc3339 now))
+       ;; normalize-stable
+       (is (= now (datetime/normalize now))))))

--- a/test/atproto/runtime/retry_test.cljc
+++ b/test/atproto/runtime/retry_test.cljc
@@ -1,0 +1,123 @@
+(ns atproto.runtime.retry-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [atproto.runtime.retry :as retry]))
+
+(deftest backoff-ms-test
+  ;; ~100, ~200, ~400, ~800, ~1000, ~1000, ... each ±15%
+  (dotimes [_ 50]
+    (let [ms (retry/backoff-ms 0)]
+      (is (<= 85.0 ms 115.0)))
+    (let [ms (retry/backoff-ms 1)]
+      (is (<= 170.0 ms 230.0)))
+    (let [ms (retry/backoff-ms 2)]
+      (is (<= 340.0 ms 460.0)))
+    ;; capped at 1000
+    (let [ms (retry/backoff-ms 10)]
+      (is (<= 850.0 ms 1150.0)))
+    ;; custom multiplier/max
+    (let [ms (retry/backoff-ms 5 :multiplier 1 :max 10)]
+      (is (<= 8.5 ms 11.5)))))
+
+(deftest abort-signal-test
+  (let [signal (retry/abort-signal)]
+    (is (false? (retry/aborted? signal)))
+    (retry/abort! signal)
+    (is (true? (retry/aborted? signal)))
+    ;; idempotent
+    (retry/abort! signal)
+    (is (true? (retry/aborted? signal))))
+  ;; nil signals are never aborted (and abort!/on-abort! tolerate them)
+  (is (false? (retry/aborted? nil)))
+  (is (nil? (retry/abort! nil)))
+  (is (nil? (retry/on-abort! nil #(throw (ex-info "boom" {}))))))
+
+(deftest on-abort-test
+  ;; listeners registered before abort! fire exactly once on abort!
+  (let [signal (retry/abort-signal)
+        calls (atom 0)]
+    (retry/on-abort! signal #(swap! calls inc))
+    (is (zero? @calls))
+    (retry/abort! signal)
+    (is (= 1 @calls))
+    (retry/abort! signal)
+    (is (= 1 @calls))
+    ;; listeners registered after abort! fire immediately
+    (retry/on-abort! signal #(swap! calls inc))
+    (is (= 2 @calls))))
+
+;; The with-retry tests use immediate callbacks, so the only asynchrony is
+;; `schedule`'s backoff sleep; a promise bridges it on the JVM.
+
+#?(:clj
+   (defn- run-retry
+     [f opts]
+     (let [result (promise)]
+       (retry/with-retry f opts #(deliver result %))
+       (deref result 5000 ::timeout))))
+
+#?(:clj
+   (deftest with-retry-success-first-try-test
+     (let [calls (atom 0)
+           f (fn [cb] (swap! calls inc) (cb {:ok true}))]
+       (is (= {:ok true} (run-retry f {:max-retries 3})))
+       (is (= 1 @calls)))))
+
+#?(:clj
+   (deftest with-retry-retryable-then-success-test
+     (let [calls (atom 0)
+           f (fn [cb]
+               (if (= 1 (swap! calls inc))
+                 (cb {:error "Timeout" :retryable? true})
+                 (cb {:ok true})))]
+       (is (= {:ok true} (run-retry f {:max-retries 3
+                                       :backoff-ms (constantly 1)})))
+       (is (= 2 @calls)))))
+
+#?(:clj
+   (deftest with-retry-respects-max-retries-test
+     (let [calls (atom 0)
+           f (fn [cb] (swap! calls inc) (cb {:error "Timeout" :retryable? true}))]
+       (is (= "Timeout" (:error (run-retry f {:max-retries 2
+                                              :backoff-ms (constantly 1)}))))
+       ;; initial attempt + 2 retries
+       (is (= 3 @calls)))))
+
+#?(:clj
+   (deftest with-retry-non-retryable-test
+     (let [calls (atom 0)
+           f (fn [cb] (swap! calls inc) (cb {:error "InvalidRequest" :retryable? false}))]
+       (is (= "InvalidRequest" (:error (run-retry f {:max-retries 3}))))
+       (is (= 1 @calls)))))
+
+#?(:clj
+   (deftest with-retry-custom-predicate-test
+     (let [calls (atom 0)
+           f (fn [cb]
+               (if (= 1 (swap! calls inc))
+                 (cb {:error "Weird"})
+                 (cb {:ok true})))]
+       (is (= {:ok true} (run-retry f {:max-retries 3
+                                       :retryable? #(= "Weird" (:error %))
+                                       :backoff-ms (constantly 1)})))
+       (is (= 2 @calls)))))
+
+#?(:clj
+   (deftest with-retry-aborted-before-start-test
+     (let [signal (retry/abort-signal)
+           calls (atom 0)
+           f (fn [cb] (swap! calls inc) (cb {:ok true}))]
+       (retry/abort! signal)
+       (is (= "Aborted" (:error (run-retry f {:max-retries 3 :signal signal}))))
+       (is (zero? @calls)))))
+
+#?(:clj
+   (deftest with-retry-aborted-between-attempts-test
+     (let [signal (retry/abort-signal)
+           calls (atom 0)
+           f (fn [cb]
+               (swap! calls inc)
+               (retry/abort! signal)
+               (cb {:error "Timeout" :retryable? true}))]
+       (is (= "Aborted" (:error (run-retry f {:max-retries 3 :signal signal}))))
+       (is (= 1 @calls)))))

--- a/test/atproto/tid_test.cljc
+++ b/test/atproto/tid_test.cljc
@@ -1,0 +1,91 @@
+(ns atproto.tid-test
+  (:require #?@(:clj [[clojure.test :refer :all]
+                      [clojure.java.io :as io]]
+                :cljs [[cljs.test :refer :all]])
+            [clojure.string :as str]
+            [atproto.tid :as tid])
+  #?(:cljs (:require-macros [atproto.tid-test :refer [interop-test-cases]])))
+
+#?(:clj
+   (defmacro interop-test-cases
+     "Return the test cases from the file at `path` in the interop test file directory.
+
+      Can be called from ClojureScript to inline the test cases."
+     [path]
+     (->> (slurp (io/resource (str "interop-test-files/" path)))
+          (str/split-lines)
+          (remove #(or (str/blank? %)
+                       (str/starts-with? % "#")))
+          (into []))))
+
+(deftest interop-fixtures-test
+  (doseq [s (interop-test-cases "syntax/tid_syntax_valid.txt")]
+    (is (tid/valid? s) (str "expected valid: " s))
+    (is (some? (tid/parse s)) (str "expected parseable: " s)))
+  (doseq [s (interop-test-cases "syntax/tid_syntax_invalid.txt")]
+    (is (not (tid/valid? s)) (str "expected invalid: " s))
+    (is (nil? (tid/parse s)) (str "expected unparseable: " s))))
+
+(deftest s32-round-trip-test
+  (doseq [n [0 1 31 32 1024 123456789 1700000000000000]]
+    (is (= n (tid/s32-decode (tid/s32-encode n)))))
+  (is (= "2" (tid/s32-encode 0)))
+  (is (= "22222" (tid/s32-encode 0 5)))
+  (is (= 0 (tid/s32-decode "2")))
+  (is (nil? (tid/s32-decode "01"))))
+
+(deftest parse-round-trip-test
+  (doseq [[micros clock-id] [[0 0]
+                             [1 0]
+                             [1 1023]
+                             [1700000000000000 42]
+                             [3 16]]]
+    (let [s (tid/from-time micros clock-id)]
+      (is (= tid/tid-length (count s)))
+      (is (tid/valid? s) (str "expected valid: " s))
+      (is (= {:timestamp micros :clock-id clock-id} (tid/parse s)))
+      (is (= micros (tid/timestamp s)))
+      (is (= clock-id (tid/clock-id s))))))
+
+(deftest padding-regression-test
+  ;; timestamps < 32^10 microseconds used to produce TIDs shorter than 13 chars
+  (let [s (tid/from-time 1 0)]
+    (is (= 13 (count s)))
+    (is (tid/valid? s))))
+
+(deftest next-tid-test
+  (let [tids (repeatedly 64 tid/next-tid)]
+    (doseq [s tids]
+      (is (= 13 (count s)))
+      (is (tid/valid? s)))
+    ;; strictly increasing
+    (is (= tids (sort tid/compare-tids (shuffle tids))))
+    (is (every? (fn [[a b]] (tid/newer? b a)) (partition 2 1 tids)))))
+
+(deftest next-tid-with-prev-test
+  ;; a prev in the past has no effect
+  (let [prev (tid/from-time 1 0)
+        tid (tid/next-tid prev)]
+    (is (tid/newer? tid prev)))
+  ;; a prev in the future forces prev's timestamp + 1
+  (let [future-micros (* 1000 1000 60 60 24 365 100) ;; ~year 2070... from epoch micros
+        prev (tid/from-time (+ (tid/timestamp (tid/next-tid)) future-micros) 0)
+        tid (tid/next-tid prev)]
+    (is (tid/newer? tid prev))
+    (is (= (inc (tid/timestamp prev)) (tid/timestamp tid))))
+  ;; nil prev behaves like the 0-arity
+  (is (tid/valid? (tid/next-tid nil))))
+
+(deftest compare-tids-test
+  (let [older (tid/from-time 1000 0)
+        newer (tid/from-time 2000 0)]
+    (is (neg? (tid/compare-tids older newer)))
+    (is (pos? (tid/compare-tids newer older)))
+    (is (zero? (tid/compare-tids older older)))
+    (is (tid/newer? newer older))
+    (is (not (tid/newer? older newer)))
+    (is (tid/older? older newer))
+    (is (not (tid/older? newer older))))
+  ;; lexicographic order = chronological order once padded
+  (let [tids (map #(tid/from-time % 0) [1 31 32 1000 32768 1700000000000000])]
+    (is (= tids (sort tids)))))

--- a/test/atproto/xrpc/client_test.cljc
+++ b/test/atproto/xrpc/client_test.cljc
@@ -316,6 +316,117 @@
                 (:atproto-accept-labelers (:headers (second @requests)))))))))
 
 #?(:clj
+   (deftest timeout-threading-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 2 (fake-http/json-response {:ok true})))
+           xrpc (client/init {:service "https://pds.test" :timeout 5000})]
+       (with-redefs [http/handle-request handler]
+         ;; the client default reaches the http request
+         (deref (client/query xrpc {:nsid "com.example.query"}) 1000 ::timeout)
+         (is (= 5000 (:timeout (first @requests))))
+         ;; a per-request timeout overrides it
+         (deref (client/query xrpc {:nsid "com.example.query" :timeout 100})
+                1000 ::timeout)
+         (is (= 100 (:timeout (second @requests))))))))
+
+#?(:clj
+   (deftest retry-test
+     ;; retryable error then success
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response 503 {:error "NotEnoughResources"})
+                                        (fake-http/json-response {:ok true})])
+           xrpc (client/init {:service "https://pds.test" :max-retries 2})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query"})
+                           5000 ::timeout)]
+           (is (= {:ok true} resp))
+           (is (= 2 (count @requests))))))
+     ;; default is a single attempt
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response 503 {:error "NotEnoughResources"})
+                                        (fake-http/json-response {:ok true})])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query"})
+                           1000 ::timeout)]
+           (is (= "NotEnoughResources" (:error resp)))
+           (is (= 1 (count @requests))))))
+     ;; non-retryable errors are not retried
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 3 (fake-http/json-response 400 {:error "InvalidRequest"})))
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query" :max-retries 3})
+                           5000 ::timeout)]
+           (is (= "InvalidRequest" (:error resp)))
+           (is (= 1 (count @requests))))))
+     ;; retries are capped by :max-retries
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 5 (fake-http/json-response 503 {:error "NotEnoughResources"})))
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query" :max-retries 2})
+                           10000 ::timeout)]
+           (is (= "NotEnoughResources" (:error resp)))
+           (is (= 3 (count @requests))))))))
+
+#?(:clj
+   (deftest abort-test
+     ;; a signal aborted before the call delivers Aborted without hitting the wire
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:ok true})])
+           xrpc (client/init {:service "https://pds.test"})
+           signal (client/abort-signal)]
+       (client/abort! signal)
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query" :signal signal})
+                           1000 ::timeout)]
+           (is (= "Aborted" (:error resp)))
+           (is (empty? @requests)))))
+     ;; aborting while the request is in flight delivers Aborted exactly once
+     (let [in-flight (promise)
+           handler (fn [_ _] (deliver in-flight true) nil) ;; never responds
+           xrpc (client/init {:service "https://pds.test"})
+           signal (client/abort-signal)]
+       (with-redefs [http/handle-request handler]
+         (let [result (client/query xrpc {:nsid "com.example.query" :signal signal})]
+           (is (true? (deref in-flight 1000 ::timeout)))
+           (client/abort! signal)
+           (is (= "Aborted" (:error (deref result 1000 ::timeout)))))))
+     ;; the discarded late result does not overwrite the abort
+     (let [respond! (atom nil)
+           handler (fn [_ cb] (reset! respond! #(cb (fake-http/json-response {:ok true}))))
+           xrpc (client/init {:service "https://pds.test"})
+           signal (client/abort-signal)]
+       (with-redefs [http/handle-request handler]
+         (let [result (client/query xrpc {:nsid "com.example.query" :signal signal})]
+           (client/abort! signal)
+           (is (= "Aborted" (:error (deref result 1000 ::timeout))))
+           ;; the http response eventually arrives and is discarded
+           (@respond!)
+           (is (= "Aborted" (:error @result))))))))
+
+#?(:clj
+   (deftest abort-during-refresh-test
+     ;; an abort tripped while the auth refresh is in flight still delivers
+     ;; exactly one Aborted error
+     (let [signal (client/abort-signal)
+           session (stub-session "old"
+                                 (fn [_ cb]
+                                   (client/abort! signal)
+                                   (cb (stub-session "new" (fn [_ cb] (cb {:error "TokenRefreshError"}))))))
+           {:keys [handler]} (fake-http/routed
+                              [[#(= "Bearer old" (bearer %)) expired-response]
+                               [#(= "Bearer new" (bearer %)) (fake-http/json-response {:ok true})]])
+           xrpc (client/init {:session session})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc"
+                                                   :body {:a 1}
+                                                   :signal signal})
+                           1000 ::timeout)]
+           (is (= "Aborted" (:error resp))))))))
+
+#?(:clj
    (deftest single-flight-refresh-test
      (let [refresh-calls (atom 0)
            release (promise)

--- a/test/atproto/xrpc/client_test.cljc
+++ b/test/atproto/xrpc/client_test.cljc
@@ -166,6 +166,156 @@
            (is (= 0 @refresh-calls)))))))
 
 #?(:clj
+   (deftest error-taxonomy-test
+     ;; a JSON error body is preserved verbatim and enriched
+     (let [{:keys [handler]} (fake-http/scripted
+                              [(fake-http/json-response 400 {:error "InvalidSwap"
+                                                             :message "Commit was at bafy..."})])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc" :body {:a 1}})
+                           1000 ::timeout)]
+           (is (= "InvalidSwap" (:error resp)))
+           (is (= "Commit was at bafy..." (:message resp)))
+           (is (= 400 (:status resp)))
+           (is (false? (:retryable? resp)))
+           (is (map? (:headers resp)))
+           (is (some? (:http-response resp))))))
+     ;; non-JSON error bodies derive the name from the status; no HTTP_<status>
+     (let [{:keys [handler]} (fake-http/scripted
+                              [{:status 502
+                                :headers {:content-type "text/html"}
+                                :body "<html>Bad Gateway</html>"}])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query"})
+                           1000 ::timeout)]
+           (is (= "UpstreamFailure" (:error resp)))
+           (is (= 502 (:status resp)))
+           (is (true? (:retryable? resp))))))
+     ;; transport failures become retryable network errors
+     (let [{:keys [handler]} (fake-http/scripted
+                              [{:error "HTTPClientError" :message "connection refused"}])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query"})
+                           1000 ::timeout)]
+           (is (= "HTTPClientError" (:error resp)))
+           (is (true? (:retryable? resp)))
+           (is (nil? (:status resp))))))))
+
+#?(:clj
+   (deftest success-headers-metadata-test
+     (let [{:keys [handler]} (fake-http/scripted
+                              [(fake-http/json-response 200
+                                                        {:ratelimit-remaining "10"}
+                                                        {:result "ok"})])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query"})
+                           1000 ::timeout)]
+           (is (= {:result "ok"} resp))
+           (is (= "10" (:ratelimit-remaining (client/response-headers resp))))
+           (is (= "application/json" (:content-type (client/response-headers resp)))))))))
+
+#?(:clj
+   (deftest request-validation-error-map-test
+     ;; client-side validation failures return an error map instead of throwing
+     (let [{:keys [handler requests]} (fake-http/scripted [])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/query xrpc {:nsid "com.example.query"
+                                               :params "not-a-map"})
+                           1000 ::timeout)]
+           (is (= "InvalidRequest" (:error resp)))
+           (is (false? (:retryable? resp)))
+           (is (some? (:explain-data resp)))
+           ;; the request never reached the wire
+           (is (empty? @requests)))))))
+
+#?(:clj
+   (deftest header-merge-test
+     ;; precedence: client defaults < per-request < computed content-type
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:ok true})])
+           xrpc (client/init {:service "https://pds.test"
+                              :headers {:x-default "client"
+                                        :x-shared "client"}})]
+       (with-redefs [http/handle-request handler]
+         (deref (client/procedure xrpc {:nsid "com.example.proc"
+                                        :body {:a 1}
+                                        :headers {:x-shared "request"
+                                                  :x-request "request"}})
+                1000 ::timeout)
+         (let [headers (:headers (first @requests))]
+           (is (= "client" (:x-default headers)))
+           (is (= "request" (:x-shared headers)))
+           (is (= "request" (:x-request headers)))
+           (is (= "application/json" (:content-type headers))))))
+     ;; supplying :content-type alongside a body is an error
+     (let [{:keys [handler requests]} (fake-http/scripted [])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/procedure xrpc {:nsid "com.example.proc"
+                                                   :body {:a 1}
+                                                   :headers {:content-type "text/plain"}})
+                           1000 ::timeout)]
+           (is (= "InvalidRequest" (:error resp)))
+           (is (empty? @requests)))))))
+
+#?(:clj
+   (deftest service-proxy-test
+     ;; client-level :service-proxy emits atproto-proxy
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 2 (fake-http/json-response {:ok true})))
+           xrpc (client/init {:service "https://pds.test"
+                              :service-proxy "did:web:api.bsky.app#bsky_appview"})]
+       (with-redefs [http/handle-request handler]
+         (deref (client/query xrpc {:nsid "com.example.query"}) 1000 ::timeout)
+         (is (= "did:web:api.bsky.app#bsky_appview"
+                (:atproto-proxy (:headers (first @requests)))))
+         ;; a per-request atproto-proxy header wins
+         (deref (client/query xrpc {:nsid "com.example.query"
+                                    :headers {:atproto-proxy "did:web:other.test#other"}})
+                1000 ::timeout)
+         (is (= "did:web:other.test#other"
+                (:atproto-proxy (:headers (second @requests)))))))
+     ;; with-service-proxy returns a routed copy of the client
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(fake-http/json-response {:ok true})])
+           xrpc (-> (client/init {:service "https://pds.test"})
+                    (client/with-service-proxy "did:web:api.bsky.app#bsky_appview"))]
+       (with-redefs [http/handle-request handler]
+         (deref (client/query xrpc {:nsid "com.example.query"}) 1000 ::timeout)
+         (is (= "did:web:api.bsky.app#bsky_appview"
+                (:atproto-proxy (:headers (first @requests)))))))
+     ;; malformed proxy strings are rejected
+     (is (thrown? #?(:clj Exception :cljs js/Error)
+                  (client/init {:service "https://pds.test"
+                                :service-proxy "not-a-proxy"})))
+     (is (thrown? #?(:clj Exception :cljs js/Error)
+                  (client/with-service-proxy (client/init {:service "https://pds.test"})
+                    "did:web:api.bsky.app")))))
+
+#?(:clj
+   (deftest labelers-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 2 (fake-http/json-response {:ok true})))
+           xrpc (-> (client/init {:service "https://pds.test"})
+                    (client/with-labelers [{:did "did:plc:label1" :redact? true}
+                                           "did:plc:label2"]))]
+       (with-redefs [http/handle-request handler]
+         (deref (client/query xrpc {:nsid "com.example.query"}) 1000 ::timeout)
+         (is (= "did:plc:label1;redact, did:plc:label2"
+                (:atproto-accept-labelers (:headers (first @requests)))))
+         ;; a per-request value is merged after the client's labelers
+         (deref (client/query xrpc {:nsid "com.example.query"
+                                    :headers {:atproto-accept-labelers "did:plc:label3"}})
+                1000 ::timeout)
+         (is (= "did:plc:label1;redact, did:plc:label2, did:plc:label3"
+                (:atproto-accept-labelers (:headers (second @requests)))))))))
+
+#?(:clj
    (deftest single-flight-refresh-test
      (let [refresh-calls (atom 0)
            release (promise)

--- a/test/atproto/xrpc/client_test.cljc
+++ b/test/atproto/xrpc/client_test.cljc
@@ -426,6 +426,121 @@
                            1000 ::timeout)]
            (is (= "Aborted" (:error resp))))))))
 
+(defn- record-page
+  ([records] (record-page records nil))
+  ([records cursor]
+   (fake-http/json-response (cond-> {:records records}
+                              cursor (assoc :cursor cursor)))))
+
+#?(:clj
+   (deftest fetch-all-test
+     ;; pages are collected, threading :cursor through the query params
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [1 2] "a")
+                                        (record-page [3] "b")
+                                        (record-page [4])])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/fetch-all xrpc {:nsid "com.example.list"})
+                           1000 ::timeout)]
+           (is (= [1 2 3 4] resp))
+           (is (= 3 (count @requests)))
+           (is (nil? (get-in (first @requests) [:query-params :cursor])))
+           (is (= "a" (get-in (second @requests) [:query-params :cursor])))
+           (is (= "b" (get-in (nth @requests 2) [:query-params :cursor]))))))
+     ;; :max-pages stops the pagination
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [1 2] "a")
+                                        (record-page [3] "b")
+                                        (record-page [4])])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/fetch-all xrpc {:nsid "com.example.list"} :max-pages 2)
+                           1000 ::timeout)]
+           (is (= [1 2 3] resp))
+           (is (= 2 (count @requests))))))
+     ;; an empty page stops the pagination even with a cursor
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [1] "a")
+                                        (record-page [] "b")
+                                        (record-page [2])])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/fetch-all xrpc {:nsid "com.example.list"})
+                           1000 ::timeout)]
+           (is (= [1] resp))
+           (is (= 2 (count @requests))))))
+     ;; an error mid-stream is delivered as the result
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [1] "a")
+                                        (fake-http/json-response 500 {:error "InternalServerError"})])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/fetch-all xrpc {:nsid "com.example.list"})
+                           1000 ::timeout)]
+           (is (= "InternalServerError" (:error resp)))
+           (is (= 2 (count @requests))))))
+     ;; custom :items-fn/:cursor-fn
+     (let [{:keys [handler]} (fake-http/scripted
+                              [(fake-http/json-response {:repos [1] :next "a"})
+                               (fake-http/json-response {:repos [2]})])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/fetch-all xrpc {:nsid "com.example.list"}
+                                             :items-fn :repos
+                                             :cursor-fn :next)
+                           1000 ::timeout)]
+           (is (= [1 2] resp)))))))
+
+#?(:clj
+   (deftest fetch-pages-test
+     ;; a reduced accumulator short-circuits
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [1 2] "a")
+                                        (record-page [3] "b")
+                                        (record-page [4])])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [resp (deref (client/fetch-pages xrpc {:nsid "com.example.list"}
+                                               (fn [acc page]
+                                                 (let [acc (into acc (:records page))]
+                                                   (if (<= 3 (count acc))
+                                                     (reduced acc)
+                                                     acc)))
+                                               [])
+                           1000 ::timeout)]
+           (is (= [1 2 3] resp))
+           (is (= 2 (count @requests))))))))
+
+#?(:clj
+   (deftest page-seq-test
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       [(record-page [1 2] "a")
+                                        (record-page [3])])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [pages (client/page-seq xrpc {:nsid "com.example.list"})]
+           (is (= [[1 2] [3]] (map :records pages)))
+           (is (= 2 (count @requests))))))
+     ;; laziness: only the realized pages are fetched
+     (let [{:keys [handler requests]} (fake-http/scripted
+                                       (repeat 10 (record-page [1] "more")))
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [pages (client/page-seq xrpc {:nsid "com.example.list"})]
+           (is (= 2 (count (take 2 pages))))
+           (is (>= 3 (count @requests))))))
+     ;; an error page ends the seq
+     (let [{:keys [handler]} (fake-http/scripted
+                              [(record-page [1] "a")
+                               (fake-http/json-response 500 {:error "InternalServerError"})])
+           xrpc (client/init {:service "https://pds.test"})]
+       (with-redefs [http/handle-request handler]
+         (let [pages (vec (client/page-seq xrpc {:nsid "com.example.list"}))]
+           (is (= 2 (count pages)))
+           (is (= [1] (:records (first pages))))
+           (is (= "InternalServerError" (:error (last pages)))))))))
+
 #?(:clj
    (deftest single-flight-refresh-test
      (let [refresh-calls (atom 0)

--- a/test/atproto/xrpc/error_test.cljc
+++ b/test/atproto/xrpc/error_test.cljc
@@ -1,0 +1,83 @@
+(ns atproto.xrpc.error-test
+  (:require #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all])
+            [atproto.xrpc.error :as xrpc-error]))
+
+(deftest status->error-name-test
+  (are [status name] (= name (xrpc-error/derived-error-name status))
+    400 "InvalidRequest"
+    401 "AuthenticationRequired"
+    403 "Forbidden"
+    404 "XRPCNotSupported"
+    406 "NotAcceptable"
+    413 "PayloadTooLarge"
+    415 "UnsupportedMediaType"
+    429 "RateLimitExceeded"
+    500 "InternalServerError"
+    501 "MethodNotImplemented"
+    502 "UpstreamFailure"
+    503 "NotEnoughResources"
+    504 "UpstreamTimeout"
+    ;; fallback buckets
+    418 "InvalidRequest"
+    422 "InvalidRequest"
+    599 "UpstreamFailure"
+    522 "UpstreamFailure"
+    100 "XRPCNotSupported"
+    301 "XRPCNotSupported"))
+
+(deftest http-error-test
+  ;; a JSON error payload always wins over the derived name
+  (let [response {:status 400
+                  :headers {:content-type "application/json"}
+                  :body {:error "InvalidSwap" :message "Commit was at bafy..."}}
+        err (xrpc-error/http-error response)]
+    (is (= "InvalidSwap" (:error err)))
+    (is (= "Commit was at bafy..." (:message err)))
+    (is (= 400 (:status err)))
+    (is (= {:content-type "application/json"} (:headers err)))
+    (is (false? (:retryable? err)))
+    (is (= response (:http-response err))))
+  ;; server error names are preserved verbatim
+  (is (= "ExpiredToken"
+         (:error (xrpc-error/http-error {:status 400 :body {:error "ExpiredToken"}}))))
+  ;; non-payload bodies fall back to the derived name with a generic message
+  (let [err (xrpc-error/http-error {:status 502 :body "<html>Bad Gateway</html>"})]
+    (is (= "UpstreamFailure" (:error err)))
+    (is (string? (:message err)))
+    (is (true? (:retryable? err))))
+  (let [err (xrpc-error/http-error {:status 404 :body {:not-an-error "x"}})]
+    (is (= "XRPCNotSupported" (:error err))))
+  ;; a map body whose :error is not a string is not an error payload
+  (is (= "InvalidRequest"
+         (:error (xrpc-error/http-error {:status 400 :body {:error 42}})))))
+
+(deftest retryable-statuses-test
+  (doseq [status [408 425 429 500 502 503 504 522 524]]
+    (is (true? (:retryable? (xrpc-error/http-error {:status status})))
+        (str "expected retryable: " status)))
+  (doseq [status [400 401 403 404 406 413 415 501 100 301 418]]
+    (is (false? (:retryable? (xrpc-error/http-error {:status status})))
+        (str "expected not retryable: " status))))
+
+(deftest network-error-test
+  (let [err (xrpc-error/network-error {:error "HTTPClientError" :message "connection refused"})]
+    (is (= "HTTPClientError" (:error err)))
+    (is (= "connection refused" (:message err)))
+    (is (true? (:retryable? err)))
+    (is (nil? (:status err))))
+  (is (= "Timeout" (:error (xrpc-error/network-error {:error "Timeout"}))))
+  (is (= "HTTPClientError" (:error (xrpc-error/network-error {})))))
+
+(deftest invalid-request-test
+  (let [err (xrpc-error/invalid-request {:problems []})]
+    (is (= "InvalidRequest" (:error err)))
+    (is (string? (:message err)))
+    (is (false? (:retryable? err)))
+    (is (= {:problems []} (:explain-data err)))))
+
+(deftest retryable?-test
+  (is (true? (xrpc-error/retryable? {:error "Timeout" :retryable? true})))
+  (is (false? (xrpc-error/retryable? {:error "InvalidRequest" :retryable? false})))
+  (is (false? (xrpc-error/retryable? {:error "InvalidRequest"})))
+  (is (false? (xrpc-error/retryable? nil))))


### PR DESCRIPTION
## Summary

This PR implements comprehensive XRPC client ergonomics including a typed error taxonomy, exponential backoff retry logic, request/response metadata handling, and convenience wrappers for the `com.atproto.repo.*` API. It also adds foundational utilities for TID parsing, at:// URI construction, and datetime normalization.

## Key Changes

**Error Handling & Taxonomy** (`src/atproto/xrpc/error.cljc`)
- Introduced a typed error taxonomy mirroring @atproto/lex-client with consistent error maps: `{:error :message? :status? :headers? :retryable? :http-response?}`
- Server-provided JSON error names are preserved verbatim; status-derived names are used only when response body lacks a valid error payload
- Retryable status detection (408, 425, 429, 5xx) with special handling for 401 (never retryable)
- Transport-level failures (`HTTPClientError`, `Timeout`) are marked retryable

**Retry Logic** (`src/atproto/runtime/retry.cljc`)
- Exponential backoff with jitter: `min(2^n * multiplier, max) ± 15%` (defaults: ~100ms base, 1000ms cap)
- Cooperative abort signals for request cancellation with listener registration
- Callback-based retry orchestration with configurable max retries

**XRPC Client Enhancements** (`src/atproto/xrpc/client.cljc`)
- Extended `init` config: `:headers`, `:service-proxy`, `:labelers`, `:timeout`, `:max-retries`
- New functions: `with-service-proxy`, `with-labelers` for client routing and labeler configuration
- Header merging with precedence: client defaults < proxy/labelers < per-request < computed
- Request validation now returns error maps instead of throwing
- Response headers attached as metadata to successful bodies via `response-headers` accessor
- Integrated retry logic with abort signal support

**Repository API** (`src/atproto/client/repo.cljc`)
- Convenience wrappers for `com.atproto.repo.*` methods: `create-record`, `get-record`, `put-record`, `delete-record`, `list-records`, `upload-blob`
- Automatic repo defaulting to authenticated DID with `NotAuthenticated` error when unavailable
- Passthrough support for `:headers`, `:timeout`, `:signal`, `:max-retries`
- Client-side validation with helpful error messages

**Utilities**
- **TID** (`src/atproto/tid.cljc`): Sort32 encoding/decoding, parsing, validation with interop test fixtures
- **at:// URI** (`src/atproto/at_uri.cljc`): Strict parsing and construction with lexicon validation
- **Datetime** (`src/atproto/runtime/datetime.cljc`): Lenient parsing (RFC 3339, local UTC, RFC 1123), canonical formatting, current datetime generation

**HTTP Runtime** (`src/atproto/runtime/http.cljc`)
- Timeout support with platform-specific error handling
- Abort signal integration for request cancellation

## Notable Implementation Details

- Error maps flow through the entire call chain, enabling graceful degradation without exceptions
- Header merging respects computed headers (e.g., `content-type`) as highest precedence to prevent conflicts
- Service proxy validation uses regex pattern matching; malformed proxies throw at client init time
- Labelers header merges client defaults with per-request values
- Request validation failures return error maps instead of throwing, preventing wire traffic
- Response metadata attachment preserves headers for successful calls while remaining transparent to non-metadata-supporting bodies
- Retry logic is callback-based to support both sync and async platforms
- All new modules include comprehensive test coverage with interop fixtures for TID/at-URI/datetime

https://claude.ai/code/session_012H6wozdL5kEchZVzWyihcx